### PR TITLE
Fixed test failure updating final fields

### DIFF
--- a/nitrite-mapdb-adapter/src/test/java/org/dizitart/no2/mapdb/repository/data/WithFinalField.java
+++ b/nitrite-mapdb-adapter/src/test/java/org/dizitart/no2/mapdb/repository/data/WithFinalField.java
@@ -51,9 +51,12 @@ public class WithFinalField implements Mappable {
         name = document.get("name", String.class);
         try {
             Field field = getClass().getDeclaredField("number");
+            field.setAccessible(true);
+
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            
             field.set(this, document.get("number", Long.class));
         } catch (Exception e) {
             throw new ObjectMappingException("failed to set value");

--- a/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/repository/data/WithFinalField.java
+++ b/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/repository/data/WithFinalField.java
@@ -51,9 +51,12 @@ public class WithFinalField implements Mappable {
         name = document.get("name", String.class);
         try {
             Field field = getClass().getDeclaredField("number");
+            field.setAccessible(true);
+
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
             field.set(this, document.get("number", Long.class));
         } catch (Exception e) {
             throw new ObjectMappingException("failed to set value");

--- a/nitrite-rocksdb-adapter/src/test/java/org/dizitart/no2/rocksdb/repository/data/WithFinalField.java
+++ b/nitrite-rocksdb-adapter/src/test/java/org/dizitart/no2/rocksdb/repository/data/WithFinalField.java
@@ -51,9 +51,12 @@ public class WithFinalField implements Mappable {
         name = document.get("name", String.class);
         try {
             Field field = getClass().getDeclaredField("number");
+            field.setAccessible(true);
+
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
             field.set(this, document.get("number", Long.class));
         } catch (Exception e) {
             throw new ObjectMappingException("failed to set value");

--- a/nitrite/src/test/java/org/dizitart/no2/repository/data/WithFinalField.java
+++ b/nitrite/src/test/java/org/dizitart/no2/repository/data/WithFinalField.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package org.dizitart.no2.repository.data;
 
 import lombok.Getter;
@@ -51,12 +52,15 @@ public class WithFinalField implements Mappable {
         name = document.get("name", String.class);
         try {
             Field field = getClass().getDeclaredField("number");
+            field.setAccessible(true);
+
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
             field.set(this, document.get("number", Long.class));
         } catch (Exception e) {
-            throw new ObjectMappingException("failed to set value");
+            throw new ObjectMappingException("failed to set value", e);
         }
     }
 }


### PR DESCRIPTION
These changes add the necessary `field.setAccessible(true);` call to `WithFinalField.java` to allow updating final fields in the tests.