### PR TITLE
Construct KotlinModule using builder instead of using deprecated constructor method

### DIFF
--- a/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/KNO2JacksonMapper.kt
+++ b/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/KNO2JacksonMapper.kt
@@ -54,7 +54,7 @@ open class KNO2JacksonMapper(vararg extensions: JacksonExtension) : JacksonMappe
         addValueType(OptionalDouble::class.java)
 
         val objectMapper = super.createObjectMapper()
-        objectMapper.registerModule(KotlinModule())
+        objectMapper.registerModule(KotlinModule.Builder().build())
         objectMapper.registerModule(Jdk8Module())
         objectMapper.registerModule(JavaTimeModule())
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)


### PR DESCRIPTION
Construct `KotlinModule()` using builder method instead of using constructor method because the latter is deprecated.

The constructor method also seems to have binary compatibility issues, see how this `.main.kts` script:

```kotlin
#!/usr/bin/env kotlin

@file:CompilerOptions("-jvm-target", "16")
@file:DependsOn("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31")

@file:DependsOn("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
@file:DependsOn("org.dizitart:potassium-nitrite:3.4.3")

import org.dizitart.kno2.nitrite

val db = nitrite {}
```

crashes with the following stack trace:
```
java.lang.NoSuchMethodError: 'void com.fasterxml.jackson.module.kotlin.KotlinModule.<init>(int, boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)'
        at org.dizitart.kno2.KNO2JacksonFacade.createObjectMapper(KNO2JacksonFacade.kt:40)
        at org.dizitart.no2.mapper.JacksonFacade.createObjectMapper(JacksonFacade.java:95)
        at org.dizitart.no2.mapper.JacksonFacade.<init>(JacksonFacade.java:63)
        at org.dizitart.kno2.KNO2JacksonFacade.<init>(KNO2JacksonFacade.kt:36)
        at org.dizitart.kno2.KNO2JacksonFacade.<init>(KNO2JacksonFacade.kt:36)
        at org.dizitart.kno2.KNO2JacksonMapper.<init>(KNO2JacksonMapper.kt:33)
        at org.dizitart.kno2.Builder.createNitriteBuilder$potassium_nitrite(Builder.kt:132)
        at org.dizitart.kno2.BuilderKt.nitrite(Builder.kt:166)
        at org.dizitart.kno2.BuilderKt.nitrite$default(Builder.kt:163)
        at Nitrite_bug_main.<init>(nitrite-bug.main.kts:11)
```

