### PR TITLE
Adding support for multi-module projects 

### DIFF
--- a/nitrite/build.gradle
+++ b/nitrite/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         exclude module: 'snakeyaml'
     }
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:2.18.0"
-    testImplementation "org.apache.logging.log4j:log4j-core:2.17.2"
+    testImplementation "org.apache.logging.log4j:log4j-core:2.18.0"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation 'joda-time:joda-time:2.10.14'
     testImplementation "org.meanbean:meanbean:2.0.3"

--- a/nitrite/src/main/java/org/dizitart/no2/Nitrite.java
+++ b/nitrite/src/main/java/org/dizitart/no2/Nitrite.java
@@ -20,6 +20,7 @@ import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.common.Constants;
 import org.dizitart.no2.exceptions.NitriteIOException;
 import org.dizitart.no2.exceptions.ValidationException;
+import org.dizitart.no2.repository.IRepositoryFinder;
 import org.dizitart.no2.repository.ObjectRepository;
 import org.dizitart.no2.store.StoreMetaData;
 import org.dizitart.no2.store.NitriteStore;
@@ -111,7 +112,11 @@ public interface Nitrite extends AutoCloseable {
      * @see ObjectRepository
      */
     <T> ObjectRepository<T> getRepository(Class<T> type, String key);
-
+ 
+    
+    
+    <T> IRepositoryFinder<T> repository(Class<T> type) ; 
+    
     /**
      * Destroys a {@link NitriteCollection} without opening it first.
      *

--- a/nitrite/src/main/java/org/dizitart/no2/NitriteDatabase.java
+++ b/nitrite/src/main/java/org/dizitart/no2/NitriteDatabase.java
@@ -25,6 +25,8 @@ import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.exceptions.NitriteIOException;
 import org.dizitart.no2.exceptions.NitriteSecurityException;
 import org.dizitart.no2.migration.MigrationManager;
+import org.dizitart.no2.repository.DefaultRepositoryFinder;
+import org.dizitart.no2.repository.IRepositoryFinder;
 import org.dizitart.no2.repository.ObjectRepository;
 import org.dizitart.no2.repository.RepositoryFactory;
 import org.dizitart.no2.store.NitriteMap;
@@ -79,6 +81,12 @@ class NitriteDatabase implements Nitrite {
         checkOpened();
         return repositoryFactory.getRepository(nitriteConfig, type, key);
     }
+    
+    @Override
+	public <T> IRepositoryFinder<T> repository(Class<T> type) {
+    	checkOpened(); 
+    	return new DefaultRepositoryFinder<>(nitriteConfig  , type, this.repositoryFactory ) ; 
+	}
 
     @Override
     public void destroyCollection(String name) {
@@ -252,4 +260,6 @@ class NitriteDatabase implements Nitrite {
             storeInfo.put(STORE_INFO, storeMetadata.getInfo());
         }
     }
+
+	
 }

--- a/nitrite/src/main/java/org/dizitart/no2/repository/DefaultRepositoryFinder.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/DefaultRepositoryFinder.java
@@ -1,0 +1,81 @@
+package org.dizitart.no2.repository;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import org.dizitart.no2.NitriteConfig;
+import org.dizitart.no2.common.meta.Attributes;
+import org.dizitart.no2.common.util.StringUtils;
+import org.dizitart.no2.repository.annotations.Id;
+
+public class DefaultRepositoryFinder<T> implements IRepositoryFinder<T> {
+
+	private final Class<T> type ; 
+	private String idField = null;
+	private String key = null;
+
+	private RepositoryFactory repositoryFactory ; 
+	private NitriteConfig nitriteConfig ; 
+    
+	
+	public DefaultRepositoryFinder(NitriteConfig nitriteConfig ,Class<T> type , RepositoryFactory factory) { 
+		this.nitriteConfig = nitriteConfig ; 
+		this.type = type ; 
+		this.repositoryFactory = factory ; 
+	}
+	
+	
+	@Override
+	public IRepositoryFinder<T> withTypeId(String idField) {
+		this.idField = idField;
+		return this;
+	}
+
+	@Override
+	public IRepositoryFinder<T> hasKey(String key) {
+		this.key = key;
+		return this;
+	}
+	
+
+	@Override
+	public ObjectRepository<T> get() {
+	 
+		Attributes attrs = new Attributes();
+			
+//		if(idField == null) { 
+//			
+//			Field[] typeFields = type.getDeclaredFields() ; 
+//			
+//			for(Field field : typeFields) { 
+//				
+//				if(field.isAnnotationPresent(Id.class)) { 
+//					idField = "" ; 
+//					break ; 
+//				}
+//			
+//				// implicit id is the field with name 'id' , so if model type defines any field
+//				// with name 'id' then we can consider
+//				// this field as ObjectIdField even if is`t annotated with @id or declared
+//				// manually by RepositoryFinder
+//
+//				if(field.getName().equals("id")) { 
+//					idField = "id" ; 
+//					attrs.set(RepositoryAttributes.ID_RECOGNITION_STRATEGY, IdRecognitionStrategy.BY_CONVENIENT.toString()) ; 
+//				}
+//				
+//			}
+//			
+//		}else { 
+//			System.out.println("Set ID Reco Strategy To " + IdRecognitionStrategy.BY_CLIENT.toString()) ; 
+// 			attrs.set(RepositoryAttributes.ID_RECOGNITION_STRATEGY, IdRecognitionStrategy.BY_CLIENT.toString()) ; 
+//			
+//		}
+//		
+		attrs.set(RepositoryAttributes.ID_FIELD_NAME, idField == null ? "" : idField ) ; 
+		
+		return this.repositoryFactory.getRepository(nitriteConfig, type, key , attrs) ; 
+	}
+
+	
+}

--- a/nitrite/src/main/java/org/dizitart/no2/repository/DefaultRepositoryFinder.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/DefaultRepositoryFinder.java
@@ -42,36 +42,7 @@ public class DefaultRepositoryFinder<T> implements IRepositoryFinder<T> {
 	public ObjectRepository<T> get() {
 	 
 		Attributes attrs = new Attributes();
-			
-//		if(idField == null) { 
-//			
-//			Field[] typeFields = type.getDeclaredFields() ; 
-//			
-//			for(Field field : typeFields) { 
-//				
-//				if(field.isAnnotationPresent(Id.class)) { 
-//					idField = "" ; 
-//					break ; 
-//				}
-//			
-//				// implicit id is the field with name 'id' , so if model type defines any field
-//				// with name 'id' then we can consider
-//				// this field as ObjectIdField even if is`t annotated with @id or declared
-//				// manually by RepositoryFinder
-//
-//				if(field.getName().equals("id")) { 
-//					idField = "id" ; 
-//					attrs.set(RepositoryAttributes.ID_RECOGNITION_STRATEGY, IdRecognitionStrategy.BY_CONVENIENT.toString()) ; 
-//				}
-//				
-//			}
-//			
-//		}else { 
-//			System.out.println("Set ID Reco Strategy To " + IdRecognitionStrategy.BY_CLIENT.toString()) ; 
-// 			attrs.set(RepositoryAttributes.ID_RECOGNITION_STRATEGY, IdRecognitionStrategy.BY_CLIENT.toString()) ; 
-//			
-//		}
-//		
+	
 		attrs.set(RepositoryAttributes.ID_FIELD_NAME, idField == null ? "" : idField ) ; 
 		
 		return this.repositoryFactory.getRepository(nitriteConfig, type, key , attrs) ; 

--- a/nitrite/src/main/java/org/dizitart/no2/repository/IRepositoryFinder.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/IRepositoryFinder.java
@@ -1,0 +1,10 @@
+package org.dizitart.no2.repository;
+
+public interface IRepositoryFinder<T> {
+
+	
+	public IRepositoryFinder<T> withTypeId(String idField) ; 
+	public IRepositoryFinder<T> hasKey(String key) ; 
+	public ObjectRepository<T> get() ; 
+	
+}

--- a/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryAttributes.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryAttributes.java
@@ -1,0 +1,8 @@
+package org.dizitart.no2.repository;
+
+public class RepositoryAttributes {
+
+	
+	public static final String ID_FIELD_NAME = "id_field_name" ; 
+	
+}

--- a/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryFactory.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryFactory.java
@@ -20,15 +20,21 @@ import org.dizitart.no2.NitriteConfig;
 import org.dizitart.no2.collection.CollectionFactory;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.common.util.StringUtils;
+import org.dizitart.no2.exceptions.InvalidIdException;
 import org.dizitart.no2.exceptions.NitriteIOException;
+import org.dizitart.no2.exceptions.NotIdentifiableException;
 import org.dizitart.no2.exceptions.ValidationException;
+import org.dizitart.no2.repository.annotations.Id;
 import org.dizitart.no2.common.mapper.NitriteMapper;
+import org.dizitart.no2.common.meta.Attributes;
 import org.dizitart.no2.store.NitriteStore;
 import org.dizitart.no2.store.StoreCatalog;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 import static org.dizitart.no2.common.util.ObjectUtils.findRepositoryName;
 
@@ -39,116 +45,265 @@ import static org.dizitart.no2.common.util.ObjectUtils.findRepositoryName;
  * @since 1.0
  */
 public class RepositoryFactory {
-    private final Map<String, ObjectRepository<?>> repositoryMap;
-    private final CollectionFactory collectionFactory;
-    private final ReentrantLock lock;
+	private final Map<String, ObjectRepository<?>> repositoryMap;
+	private final CollectionFactory collectionFactory;
+	private final ReentrantLock lock;
 
-    /**
-     * Instantiates a new {@link RepositoryFactory}.
-     *
-     * @param collectionFactory the collection factory
-     */
-    public RepositoryFactory(CollectionFactory collectionFactory) {
-        this.collectionFactory = collectionFactory;
-        this.repositoryMap = new HashMap<>();
-        this.lock = new ReentrantLock();
-    }
+	/**
+	 * Instantiates a new {@link RepositoryFactory}.
+	 *
+	 * @param collectionFactory the collection factory
+	 */
+	public RepositoryFactory(CollectionFactory collectionFactory) {
+		this.collectionFactory = collectionFactory;
+		this.repositoryMap = new HashMap<>();
+		this.lock = new ReentrantLock();
+	}
 
-    /**
-     * Gets an {@link ObjectRepository} by type.
-     *
-     * @param <T>           the type parameter
-     * @param nitriteConfig the nitrite config
-     * @param type          the type
-     * @return the repository
-     */
-    public <T> ObjectRepository<T> getRepository(NitriteConfig nitriteConfig, Class<T> type) {
-        return getRepository(nitriteConfig, type, null);
-    }
+	/**
+	 * Gets an {@link ObjectRepository} by type.
+	 *
+	 * @param <T>           the type parameter
+	 * @param nitriteConfig the nitrite config
+	 * @param type          the type
+	 * @return the repository
+	 */
+	public <T> ObjectRepository<T> getRepository(NitriteConfig nitriteConfig, Class<T> type) {
+		return getRepository(nitriteConfig, type, null);
+	}
 
-    /**
-     * Gets an {@link ObjectRepository} by type and a key.
-     *
-     * @param <T>           the type parameter
-     * @param nitriteConfig the nitrite config
-     * @param type          the type
-     * @param key           the key
-     * @return the repository
-     */
-    @SuppressWarnings("unchecked")
-    public <T> ObjectRepository<T> getRepository(NitriteConfig nitriteConfig, Class<T> type, String key) {
-        if (type == null) {
-            throw new ValidationException("type cannot be null");
-        }
+	/**
+	 * Gets an {@link ObjectRepository} by type and a key and specify the id field
+	 * name.
+	 * 
+	 * this method allow you to specify the id field name for the passed model type
+	 * 
+	 * @param <T>           the type parameter
+	 * @param nitriteConfig the nitrite config
+	 * @param type          the type
+	 * @param key           the key
+	 * @param attrs         repository attributes , which can be used to control
+	 *                      object repository behavior
+	 * @throws InvalidIdException where id field name change after first creation of
+	 *                            the repository .
+	 * 
+	 *                            <p>
+	 *                            suppose the following scenario
+	 * 
+	 *                            <pre>
+	 *                            class a {
+	 * 
+	 *                            	doSomeThing(){
+	 * 
+	 *                            	db.repository(Model.class)
+	 *                            	.withKey("repo")
+	 *                            	.withTypeId("model_id").get();
+	 *                            	}
+	 * 
+	 *                            }
+	 * 
+	 *                            class b {
+	 * 
+	 *                            	doSomeThing(){
+	 * 
+	 *                            	db.repository(Model.class)
+	 *                            	.withKey("repo")
+	 *                            	.withTypeId("other_id").get();
+	 * 
+	 *                            	}
+	 * 
+	 *                            }
+	 * 
+	 *                            </pre>
+	 *                            </p>
+	 * 
+	 * @return the repository
+	 */
+	public <T> ObjectRepository<T> getRepository(NitriteConfig nitriteConfig, Class<T> type, String key,
+			Attributes attrs) {
 
-        if (nitriteConfig == null) {
-            throw new ValidationException("nitriteConfig cannot be null");
-        }
+		if (type == null) {
+			throw new ValidationException("type cannot be null");
+		}
 
-        String collectionName = findRepositoryName(type, key);
+		if (nitriteConfig == null) {
+			throw new ValidationException("nitriteConfig cannot be null");
+		}
+		// if(attrs == null) {
+		// attrs = new Attributes() ;
+		// }
 
-        try {
-            lock.lock();
-            if (repositoryMap.containsKey(collectionName)) {
-                ObjectRepository<T> repository = (ObjectRepository<T>) repositoryMap.get(collectionName);
-                if (repository.isDropped() || !repository.isOpen()) {
-                    repositoryMap.remove(collectionName);
-                    return createRepository(nitriteConfig, type, collectionName, key);
-                } else {
-                    return repository;
-                }
-            } else {
-                return createRepository(nitriteConfig, type, collectionName, key);
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
+		String collectionName = findRepositoryName(type, key);
 
-    /**
-     * Closes all opened {@link ObjectRepository}s and clear internal data from this class.
-     */
-    public void clear() {
-        try {
-            lock.lock();
-            for (ObjectRepository<?> repository : repositoryMap.values()) {
-                repository.close();
-            }
-            repositoryMap.clear();
-        } catch (Exception e) {
-            throw new NitriteIOException("Failed to clear an object repository", e);
-        } finally {
-            lock.unlock();
-        }
-    }
+		try {
+			lock.lock();
+			if (repositoryMap.containsKey(collectionName)) {
+				ObjectRepository<T> repository = (ObjectRepository<T>) repositoryMap.get(collectionName);
+				if (repository.isDropped() || !repository.isOpen()) {
+					repositoryMap.remove(collectionName);
+					return createRepository(nitriteConfig, type, collectionName, key, attrs);
+				} else {
+					Attributes cachedRepoAttrs = repository.getAttributes();
+					String idFieldName = (attrs != null) ? attrs.get(RepositoryAttributes.ID_FIELD_NAME) : "";
+					String cachedIdFN = (cachedRepoAttrs != null)
+							? cachedRepoAttrs.get(RepositoryAttributes.ID_FIELD_NAME)
+							: "";
 
-    private <T> ObjectRepository<T> createRepository(NitriteConfig nitriteConfig, Class<T> type,
-                                                     String collectionName, String key) {
-        NitriteMapper nitriteMapper = nitriteConfig.nitriteMapper();
-        NitriteStore<?> store = nitriteConfig.getNitriteStore();
-        if (nitriteMapper.isValueType(type)) {
-            throw new ValidationException("Cannot create a repository for a value type");
-        }
+					boolean isValidId = true;
 
-        if (store.getCollectionNames().contains(collectionName)) {
-            throw new ValidationException("A collection with same entity name already exists");
-        }
+					if (StringUtils.isNullOrEmpty(idFieldName)) {
 
-        NitriteCollection nitriteCollection = collectionFactory.getCollection(collectionName,
-            nitriteConfig, false);
-        ObjectRepository<T> repository = new DefaultObjectRepository<>(type, nitriteCollection, nitriteConfig);
-        repositoryMap.put(collectionName, repository);
+						if (!StringUtils.isNullOrEmpty(cachedIdFN)) {
+							String typeId = getTypeId(type);
+							isValidId = cachedIdFN.equals(typeId);
+						}
 
-        writeCatalog(store, collectionName, key);
-        return repository;
-    }
+					} else {
 
-    private void writeCatalog(NitriteStore<?> store, String name, String key) {
-        StoreCatalog storeCatalog = store.getCatalog();
-        if (StringUtils.isNullOrEmpty(key)) {
-            storeCatalog.writeRepositoryEntry(name);
-        } else {
-            storeCatalog.writeKeyedRepositoryEntry(name);
-        }
-    }
+						if (StringUtils.isNullOrEmpty(cachedIdFN)) {
+							String typeId = getTypeId(type);
+							isValidId = idFieldName.equals(typeId);
+						} else {
+							isValidId = cachedIdFN.equals(idFieldName);
+						}
+
+					}
+
+					if (!isValidId) {
+						throw new InvalidIdException("Invalid id field name  { " + idFieldName
+								+ " } id field name expected to be fixed during runtime  " + " , repository "
+								+ collectionName + " already exists where id field name is { " + cachedIdFN + " } ");
+
+					}
+
+					return repository;
+				}
+			} else {
+				System.out.println("Try To Get New Repo ");
+				return createRepository(nitriteConfig, type, collectionName, key, attrs);
+			}
+		} finally {
+			lock.unlock();
+		}
+
+	}
+
+	private <T> String getTypeId(Class<T> type) {
+		String fieldName = "";
+
+		boolean idAnnoExists = false;
+		for (Field f : type.getDeclaredFields()) {
+
+			if (f.isAnnotationPresent(Id.class)) {
+				if (!idAnnoExists) {
+					fieldName = f.getName();
+					idAnnoExists = true;
+				} else {
+					throw new NotIdentifiableException("Id annotation can not exists more than once");
+				}
+			}
+
+			if (!idAnnoExists && f.getName().equals("id"))
+				fieldName = "id";
+
+		}
+
+		return fieldName;
+	}
+
+	/**
+	 * Gets an {@link ObjectRepository} by type and a key.
+	 *
+	 * @param <T>           the type parameter
+	 * @param nitriteConfig the nitrite config
+	 * @param type          the type
+	 * @param key           the key
+	 * @return the repository
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> ObjectRepository<T> getRepository(NitriteConfig nitriteConfig, Class<T> type, String key) {
+
+		return getRepository(nitriteConfig, type, key, null);
+
+//		if (type == null) {
+//			throw new ValidationException("type cannot be null");
+//		}
+//
+//		if (nitriteConfig == null) {
+//			throw new ValidationException("nitriteConfig cannot be null");
+//		}
+//
+//		String collectionName = findRepositoryName(type, key);
+//
+//		try {
+//			lock.lock();
+//			if (repositoryMap.containsKey(collectionName)) {
+//				ObjectRepository<T> repository = (ObjectRepository<T>) repositoryMap.get(collectionName);
+//				if (repository.isDropped() || !repository.isOpen()) {
+//					repositoryMap.remove(collectionName);
+//					return createRepository(nitriteConfig, type, collectionName, key);
+//				} else {
+//					return repository;
+//				}
+//			} else {
+//				return createRepository(nitriteConfig, type, collectionName, key);
+//			}
+//		} finally {
+//			lock.unlock();
+//		}
+
+	}
+
+	/**
+	 * Closes all opened {@link ObjectRepository}s and clear internal data from this
+	 * class.
+	 */
+	public void clear() {
+		try {
+			lock.lock();
+			for (ObjectRepository<?> repository : repositoryMap.values()) {
+				repository.close();
+			}
+			repositoryMap.clear();
+		} catch (Exception e) {
+			throw new NitriteIOException("Failed to clear an object repository", e);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	private <T> ObjectRepository<T> createRepository(NitriteConfig nitriteConfig, Class<T> type, String collectionName,
+			String key, Attributes attrs) {
+
+		NitriteMapper nitriteMapper = nitriteConfig.nitriteMapper();
+		NitriteStore<?> store = nitriteConfig.getNitriteStore();
+		if (nitriteMapper.isValueType(type)) {
+			throw new ValidationException("Cannot create a repository for a value type");
+		}
+
+		if (store.getCollectionNames().contains(collectionName)) {
+			throw new ValidationException("A collection with same entity name already exists");
+		}
+
+		NitriteCollection nitriteCollection = collectionFactory.getCollection(collectionName, nitriteConfig, false);
+
+		if (attrs != null) {
+			nitriteCollection.setAttributes(attrs);
+		}
+		ObjectRepository<T> repository = new DefaultObjectRepository<>(type, nitriteCollection, nitriteConfig);
+
+		repositoryMap.put(collectionName, repository);
+
+		writeCatalog(store, collectionName, key);
+		return repository;
+	}
+
+	private void writeCatalog(NitriteStore<?> store, String name, String key) {
+		StoreCatalog storeCatalog = store.getCatalog();
+		if (StringUtils.isNullOrEmpty(key)) {
+			storeCatalog.writeRepositoryEntry(name);
+		} else {
+			storeCatalog.writeKeyedRepositoryEntry(name);
+		}
+	}
 }

--- a/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryOperations.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryOperations.java
@@ -19,14 +19,21 @@ package org.dizitart.no2.repository;
 import org.dizitart.no2.collection.*;
 import org.dizitart.no2.common.mapper.NitriteMapper;
 import org.dizitart.no2.common.tuples.Pair;
+import org.dizitart.no2.common.util.StringUtils;
 import org.dizitart.no2.exceptions.InvalidIdException;
 import org.dizitart.no2.exceptions.NotIdentifiableException;
 import org.dizitart.no2.exceptions.ObjectMappingException;
 import org.dizitart.no2.exceptions.ValidationException;
 import org.dizitart.no2.filters.Filter;
 import org.dizitart.no2.filters.NitriteFilter;
+import org.dizitart.no2.index.IndexType;
+import org.dizitart.no2.repository.annotations.Embedded;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.dizitart.no2.common.Constants.DOC_ID;
 import static org.dizitart.no2.common.util.ObjectUtils.isCompatibleTypes;
@@ -42,210 +49,277 @@ import static org.dizitart.no2.common.util.StringUtils.isNullOrEmpty;
  * @since 4.0
  */
 public class RepositoryOperations {
-    private final NitriteMapper nitriteMapper;
-    private final Class<?> type;
-    private final NitriteCollection collection;
-    private final AnnotationScanner annotationScanner;
-    private ObjectIdField objectIdField;
+	private final NitriteMapper nitriteMapper;
+	private final Class<?> type;
+	private final NitriteCollection collection;
+	private final AnnotationScanner annotationScanner;
+	private ObjectIdField objectIdField;
 
-    /**
-     * Instantiates a new {@link RepositoryOperations}.
-     *
-     * @param type          the type
-     * @param nitriteMapper the nitrite mapper
-     * @param collection    the collection
-     */
-    public RepositoryOperations(Class<?> type,
-                                NitriteMapper nitriteMapper,
-                                NitriteCollection collection) {
-        this.type = type;
-        this.nitriteMapper = nitriteMapper;
-        this.collection = collection;
-        this.annotationScanner = new AnnotationScanner(type, collection, nitriteMapper);
-        validateCollection();
-    }
+	/**
+	 * Instantiates a new {@link RepositoryOperations}.
+	 *
+	 * @param type          the type
+	 * @param nitriteMapper the nitrite mapper
+	 * @param collection    the collection
+	 */
+	public RepositoryOperations(Class<?> type, NitriteMapper nitriteMapper, NitriteCollection collection) {
+		this.type = type;
+		this.nitriteMapper = nitriteMapper;
+		this.collection = collection;
+		this.annotationScanner = new AnnotationScanner(type, collection, nitriteMapper);
+		validateCollection();
+	}
 
-    /**
-     * Create indices.
-     */
-    public void createIndices() {
-        annotationScanner.scanIndices();
-        annotationScanner.createIndices();
-        annotationScanner.createIdIndex();
-        objectIdField = annotationScanner.getObjectIdField();
-    }
+	/**
+	 * Create indices.
+	 */
+	public void createIndices() {
+		// annotationScanner.scanIndices();
+		// annotationScanner.createIndices();
+		// annotationScanner.createIdIndex();
+		// objectIdField = annotationScanner.getObjectIdField();
+		// this.collection.getAttributes().set(RepositoryAttributes.ID_FIELD_NAME,
+		// objectIdField.getIdFieldName());
 
-    /**
-     * Serialize fields.
-     *
-     * @param document the document
-     */
-    public void serializeFields(Document document) {
-        if (document != null) {
-            for (Pair<String, Object> pair : document) {
-                String key = pair.getFirst();
-                Object value = pair.getSecond();
-                Object serializedValue;
-                serializedValue = nitriteMapper.convert(value, Document.class);
-                document.put(key, serializedValue);
-            }
-        }
-    }
+		createIndices(null);
+	}
 
-    /**
-     * To documents document [ ].
-     *
-     * @param <T>    the type parameter
-     * @param others the others
-     * @return the document [ ]
-     */
-    public <T> Document[] toDocuments(T[] others) {
-        if (others == null || others.length == 0) return null;
-        Document[] documents = new Document[others.length];
-        for (int i = 0; i < others.length; i++) {
-            documents[i] = toDocument(others[i], false); // this method is for insert only
-        }
-        return documents;
-    }
+	public void createIndices(String idFieldName) {
 
-    /**
-     * To document document.
-     *
-     * @param <T>    the type parameter
-     * @param object the object
-     * @param update the update
-     * @return the document
-     */
-    public <T> Document toDocument(T object, boolean update) {
-        Document document = nitriteMapper.convert(object, Document.class);
-        if (document == null) {
-            throw new ObjectMappingException("Failed to map object to document");
-        }
+		// if no id field name specified manually then try to check annotations
+		if (StringUtils.isNullOrEmpty(idFieldName)) {
 
-        if (objectIdField != null) {
-            Field idField = objectIdField.getField();
+			annotationScanner.scanIndices();
+			annotationScanner.createIndices();
+			annotationScanner.createIdIndex();
+			objectIdField = annotationScanner.getObjectIdField();
 
-            if (idField.getType() == NitriteId.class) {
-                try {
-                    idField.setAccessible(true);
-                    if (idField.get(object) == null) {
-                        NitriteId id = document.getId();
-                        idField.set(object, id);
-                        document.put(objectIdField.getIdFieldName(), nitriteMapper.convert(id, Comparable.class));
-                    } else if (!update) {
-                        // if it is an insert, then we should not allow to insert the document with user provided id
-                        throw new InvalidIdException("Auto generated id should not be set manually");
-                    }
-                } catch (IllegalAccessException iae) {
-                    throw new InvalidIdException("Auto generated id value cannot be accessed");
-                }
-            }
+			// if is still null 
+			 if(objectIdField == null) { 
+					tryFindImplicitId();
+			 }
 
-            Object idValue = document.get(objectIdField.getIdFieldName());
-            if (idValue == null) {
-                throw new InvalidIdException("Id cannot be null");
-            }
-            if (idValue instanceof String && isNullOrEmpty((String) idValue)) {
-                throw new InvalidIdException("Id value cannot be empty string");
-            }
-        }
-        return document;
-    }
+		} else {
 
-    /**
-     * Create unique filter filter.
-     *
-     * @param object the object
-     * @return the filter
-     */
-    public Filter createUniqueFilter(Object object) {
-        if (objectIdField == null) {
-            throw new NotIdentifiableException("No id value found for the object");
-        }
+		 Field idField = 	getFieldWithName(idFieldName)
+			.orElseThrow(()->new InvalidIdException("Invalid id " + idFieldName)) ;
+  
+		    createObjectIdFieldWithField(idField);
+	
+			//this.collection.getAttributes().set(RepositoryAttributes.ID_FIELD_NAME, objectIdField.getIdFieldName());
+			//this.collection.getAttributes().set(RepositoryAttributes.ID_RECOGNITION_STRATEGY,
+				//	IdRecognitionStrategy.BY_CLIENT.toString());
 
-        Field idField = objectIdField.getField();
-        idField.setAccessible(true);
-        try {
-            Object value = idField.get(object);
-            if (value == null) {
-                throw new InvalidIdException("Id value cannot be null");
-            }
-            return objectIdField.createUniqueFilter(value, nitriteMapper);
-        } catch (IllegalAccessException iae) {
-            throw new InvalidIdException("Id field is not accessible");
-        }
-    }
+		}
 
-    /**
-     * Remove nitrite id.
-     *
-     * @param document the document
-     */
-    public void removeNitriteId(Document document) {
-        document.remove(DOC_ID);
-        if (objectIdField != null) {
-            Field idField = objectIdField.getField();
-            if (idField != null && !objectIdField.isEmbedded()
-                && idField.getType() == NitriteId.class) {
-                document.remove(idField.getName());
-            }
-        }
-    }
+	}
 
-    /**
-     * Create id filter filter.
-     *
-     * @param <I> the type parameter
-     * @param id  the id
-     * @return the filter
-     */
-    public <I> Filter createIdFilter(I id) {
-        if (objectIdField != null) {
-            if (id == null) {
-                throw new InvalidIdException("Id cannot be null");
-            }
-            if (!isCompatibleTypes(id.getClass(), objectIdField.getField().getType())) {
-                throw new InvalidIdException("A value of invalid type is provided as id");
-            }
+	private void createObjectIdFieldWithField(Field idField) {
+		collection.dropAllIndices();
 
-            return objectIdField.createUniqueFilter(id, nitriteMapper);
-        } else {
-            throw new NotIdentifiableException(type.getName() + " does not have any id field");
-        }
-    }
+		objectIdField = new ObjectIdField();
+		objectIdField.setField(idField);
+		objectIdField.setIdFieldName(idField.getName());
+		objectIdField.setEmbedded(false); // currently embedded fields for manually defined id not supported
 
-    /**
-     * As object filter filter.
-     *
-     * @param filter the filter
-     * @return the filter
-     */
-    public Filter asObjectFilter(Filter filter) {
-        if (filter instanceof NitriteFilter) {
-            NitriteFilter nitriteFilter = (NitriteFilter) filter;
-            nitriteFilter.setObjectFilter(true);
-            return nitriteFilter;
-        }
-        return filter;
-    }
+		// create id index ;
 
-    /**
-     * Find cursor.
-     *
-     * @param <T>         the type parameter
-     * @param filter      the filter
-     * @param findOptions the find options
-     * @param type        the type
-     * @return the cursor
-     */
-    public <T> Cursor<T> find(Filter filter, FindOptions findOptions, Class<T> type) {
-        DocumentCursor documentCursor = collection.find(asObjectFilter(filter), findOptions);
-        return new ObjectCursor<>(nitriteMapper, documentCursor, type);
-    }
+		String[] fieldNames = objectIdField.getFieldNames(nitriteMapper);
+		if (!collection.hasIndex(fieldNames)) {
 
-    private void validateCollection() {
-        if (collection == null) {
-            throw new ValidationException("Repository has not been initialized properly");
-        }
-    }
+			collection.createIndex(fieldNames);
+		}
+	}
+
+	private Optional<Field> getFieldWithName(String name) {
+
+		return Stream.of(type.getDeclaredFields()).filter((f) -> f.getName().equals(name)).findFirst();
+	}
+
+	private void tryFindImplicitId() {
+
+		 getFieldWithName("id").ifPresent((idField)->{
+			createObjectIdFieldWithField(idField);
+		//	this.collection.getAttributes().set(RepositoryAttributes.ID_FIELD_NAME, objectIdField.getIdFieldName());
+			//this.collection.getAttributes().set(RepositoryAttributes.ID_RECOGNITION_STRATEGY,
+				//	IdRecognitionStrategy.BY_CONVENIENT.toString());
+
+		});
+		
+	}
+
+	/**
+	 * Serialize fields.
+	 *
+	 * @param document the document
+	 */
+	public void serializeFields(Document document) {
+		if (document != null) {
+			for (Pair<String, Object> pair : document) {
+				String key = pair.getFirst();
+				Object value = pair.getSecond();
+				Object serializedValue;
+				serializedValue = nitriteMapper.convert(value, Document.class);
+				document.put(key, serializedValue);
+			}
+		}
+	}
+
+	/**
+	 * To documents document [ ].
+	 *
+	 * @param <T>    the type parameter
+	 * @param others the others
+	 * @return the document [ ]
+	 */
+	public <T> Document[] toDocuments(T[] others) {
+		if (others == null || others.length == 0)
+			return null;
+		Document[] documents = new Document[others.length];
+		for (int i = 0; i < others.length; i++) {
+			documents[i] = toDocument(others[i], false); // this method is for insert only
+		}
+		return documents;
+	}
+
+	/**
+	 * To document document.
+	 *
+	 * @param <T>    the type parameter
+	 * @param object the object
+	 * @param update the update
+	 * @return the document
+	 */
+	public <T> Document toDocument(T object, boolean update) {
+		Document document = nitriteMapper.convert(object, Document.class);
+		if (document == null) {
+			throw new ObjectMappingException("Failed to map object to document");
+		}
+
+		if (objectIdField != null) {
+			Field idField = objectIdField.getField();
+
+			if (idField.getType() == NitriteId.class) {
+				try {
+					idField.setAccessible(true);
+					if (idField.get(object) == null) {
+						NitriteId id = document.getId();
+						idField.set(object, id);
+						document.put(objectIdField.getIdFieldName(), nitriteMapper.convert(id, Comparable.class));
+					} else if (!update) {
+						// if it is an insert, then we should not allow to insert the document with user
+						// provided id
+						throw new InvalidIdException("Auto generated id should not be set manually");
+					}
+				} catch (IllegalAccessException iae) {
+					throw new InvalidIdException("Auto generated id value cannot be accessed");
+				}
+			}
+
+			Object idValue = document.get(objectIdField.getIdFieldName());
+			if (idValue == null) {
+				throw new InvalidIdException("Id cannot be null");
+			}
+			if (idValue instanceof String && isNullOrEmpty((String) idValue)) {
+				throw new InvalidIdException("Id value cannot be empty string");
+			}
+		}
+		return document;
+	}
+
+	/**
+	 * Create unique filter filter.
+	 *
+	 * @param object the object
+	 * @return the filter
+	 */
+	public Filter createUniqueFilter(Object object) {
+		if (objectIdField == null) {
+			throw new NotIdentifiableException("No id value found for the object");
+		}
+
+		Field idField = objectIdField.getField();
+		idField.setAccessible(true);
+		try {
+			Object value = idField.get(object);
+			if (value == null) {
+				throw new InvalidIdException("Id value cannot be null");
+			}
+			return objectIdField.createUniqueFilter(value, nitriteMapper);
+		} catch (IllegalAccessException iae) {
+			throw new InvalidIdException("Id field is not accessible");
+		}
+	}
+
+	/**
+	 * Remove nitrite id.
+	 *
+	 * @param document the document
+	 */
+	public void removeNitriteId(Document document) {
+		document.remove(DOC_ID);
+		if (objectIdField != null) {
+			Field idField = objectIdField.getField();
+			if (idField != null && !objectIdField.isEmbedded() && idField.getType() == NitriteId.class) {
+				document.remove(idField.getName());
+			}
+		}
+	}
+
+	/**
+	 * Create id filter filter.
+	 *
+	 * @param <I> the type parameter
+	 * @param id  the id
+	 * @return the filter
+	 */
+	public <I> Filter createIdFilter(I id) {
+		if (objectIdField != null) {
+			if (id == null) {
+				throw new InvalidIdException("Id cannot be null");
+			}
+			if (!isCompatibleTypes(id.getClass(), objectIdField.getField().getType())) {
+				throw new InvalidIdException("A value of invalid type is provided as id");
+			}
+
+			return objectIdField.createUniqueFilter(id, nitriteMapper);
+		} else {
+			throw new NotIdentifiableException(type.getName() + " does not have any id field");
+		}
+	}
+
+	/**
+	 * As object filter filter.
+	 *
+	 * @param filter the filter
+	 * @return the filter
+	 */
+	public Filter asObjectFilter(Filter filter) {
+		if (filter instanceof NitriteFilter) {
+			NitriteFilter nitriteFilter = (NitriteFilter) filter;
+			nitriteFilter.setObjectFilter(true);
+			return nitriteFilter;
+		}
+		return filter;
+	}
+
+	/**
+	 * Find cursor.
+	 *
+	 * @param <T>         the type parameter
+	 * @param filter      the filter
+	 * @param findOptions the find options
+	 * @param type        the type
+	 * @return the cursor
+	 */
+	public <T> Cursor<T> find(Filter filter, FindOptions findOptions, Class<T> type) {
+		DocumentCursor documentCursor = collection.find(asObjectFilter(filter), findOptions);
+		return new ObjectCursor<>(nitriteMapper, documentCursor, type);
+	}
+
+	private void validateCollection() {
+		if (collection == null) {
+			throw new ValidationException("Repository has not been initialized properly");
+		}
+	}
 }

--- a/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryOperations.java
+++ b/nitrite/src/main/java/org/dizitart/no2/repository/RepositoryOperations.java
@@ -106,9 +106,6 @@ public class RepositoryOperations {
   
 		    createObjectIdFieldWithField(idField);
 	
-			//this.collection.getAttributes().set(RepositoryAttributes.ID_FIELD_NAME, objectIdField.getIdFieldName());
-			//this.collection.getAttributes().set(RepositoryAttributes.ID_RECOGNITION_STRATEGY,
-				//	IdRecognitionStrategy.BY_CLIENT.toString());
 
 		}
 
@@ -140,9 +137,6 @@ public class RepositoryOperations {
 
 		 getFieldWithName("id").ifPresent((idField)->{
 			createObjectIdFieldWithField(idField);
-		//	this.collection.getAttributes().set(RepositoryAttributes.ID_FIELD_NAME, objectIdField.getIdFieldName());
-			//this.collection.getAttributes().set(RepositoryAttributes.ID_RECOGNITION_STRATEGY,
-				//	IdRecognitionStrategy.BY_CONVENIENT.toString());
 
 		});
 		

--- a/nitrite/src/test/java/org/dizitart/no2/repository/DefaultRepositoryFinderTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/repository/DefaultRepositoryFinderTest.java
@@ -1,0 +1,414 @@
+package org.dizitart.no2.repository;
+
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.AssertTrue;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.exceptions.InvalidIdException;
+import org.dizitart.no2.exceptions.NotIdentifiableException;
+import org.dizitart.no2.exceptions.ValidationException;
+import org.dizitart.no2.repository.annotations.Entity;
+import org.dizitart.no2.repository.annotations.Id;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class DefaultRepositoryFinderTest {
+
+	private static Nitrite db;
+
+	@BeforeClass
+	public static void init() {
+		db = Nitrite.builder().openOrCreate();
+
+	}
+
+
+	@Test
+	public void testFindRepoWhenClosed() {
+
+		ObjectRepository<Item> repo = db.repository(Item.class).get();
+		assertTrue(repo.isOpen());
+
+		repo.close();
+
+		assertFalse(repo.isOpen());
+
+		ObjectRepository<Item> newRepo = db.repository(Item.class).get();
+
+		assertNotSame(repo, newRepo);
+
+		newRepo.close();
+
+		assertFalse(newRepo.isOpen());
+	}
+
+	@Test
+	public void testFindNotIdentifiableRepo() { 
+		
+		ObjectRepository<NotIdentifiableItem> repo = db.repository(NotIdentifiableItem.class).get() ;
+		
+		assertTrue(repo.isOpen());
+		assertThrows(NotIdentifiableException.class, ()->repo.getById(1)) ; 
+		
+	}
+	
+	@Test
+	public void testFindRepoByClient() {
+
+		ObjectRepository<Item> repoByClient = db.repository(Item.class).withTypeId("id").get();
+
+		assertTrue(repoByClient.isOpen());
+		repoByClient.close();
+	}
+ 
+
+	@Test
+	public void testFindRepoByClientWithKey() {
+
+		ObjectRepository<Item> item = db.repository(Item.class).hasKey("test2").withTypeId("id").get();
+		ObjectRepository<Item> itemRepo2 = db.repository(Item.class).hasKey("theKey").withTypeId("id").get() ; 
+		ObjectRepository<Item> itemRepo3 = db.repository(Item.class).get() ; 
+		ObjectRepository<Item> itemRepo4 = db.repository(Item.class).hasKey("theKey").get() ;  
+				
+		assertTrue(item.isOpen());
+		assertTrue(itemRepo2.isOpen());
+		assertTrue(itemRepo3.isOpen());
+		assertTrue(itemRepo4.isOpen()) ; 
+		
+		assertNotSame(item, itemRepo2 );
+		assertNotSame(itemRepo2 , itemRepo3) ; 
+		assertNotSame(item , itemRepo3) ; 
+		assertSame(itemRepo2 , itemRepo4) ; 
+		
+		itemRepo2.close();
+		itemRepo3.close();
+		item.close();
+
+	}
+
+
+	@Test
+	public void testFindRepoByClientWithKeyAndInvalidID() {
+
+		ObjectRepository<Item> item = db.repository(Item.class).hasKey("theKey").withTypeId("id").get();
+
+		assertTrue(item.isOpen());
+		
+ 
+		assertThrows(InvalidIdException.class, ()->db.repository(Item.class).hasKey("theKey").withTypeId("itemName").get()) ; 
+		
+		item.close();
+
+	}
+
+
+	
+	@Test
+	public void testFindRepoByClientWithInvalidID() { 
+		
+		
+		assertThrows(InvalidIdException.class,()->db.repository(Item.class).withTypeId("invalidId").get() ) ; 
+	}
+
+
+	
+	@Test
+	public void testFindRepoByConvenient() {
+
+		ObjectRepository<Item> repoByConvenient = db.repository(Item.class).get();
+
+
+		assertTrue(repoByConvenient.isOpen());
+
+		repoByConvenient.close();
+		assertFalse(repoByConvenient.isOpen());
+	}
+
+	@Test
+	public void testFindRepoByConvWithKey() { 
+	 
+		ObjectRepository<Item> repoByConv = db.repository(Item.class).get() ; 
+		ObjectRepository<Item> repoByConv2 = db.repository(Item.class).hasKey("theKey").get() ; 
+		ObjectRepository<Item> repoByConv3 = db.repository(Item.class).hasKey("theKey2").get() ; 
+		
+		assertTrue(repoByConv.isOpen()) ; 
+		assertTrue(repoByConv2.isOpen()) ; 
+		assertTrue(repoByConv3.isOpen()) ; 
+		
+		assertNotSame(repoByConv , repoByConv2) ; 
+		assertNotSame(repoByConv2 , repoByConv3) ; 
+		assertNotSame(repoByConv , repoByConv3) ; 
+		
+		repoByConv.close(); 
+		repoByConv2.close();
+		repoByConv3.close();
+		
+		
+	}
+
+	@Test
+	public void testFindRepoByConvWithKeyAndInvaliId() { 
+		ObjectRepository<Item> repoByConv = db.repository(Item.class).hasKey("theKey").get() ; 
+		
+		assertTrue(repoByConv.isOpen());
+		
+		assertThrows(InvalidIdException.class , ()->db.repository(Item.class).hasKey("theKey").withTypeId("itemName").get()) ; 
+		
+		repoByConv.close();
+		
+	}
+	
+	@Test
+	public void testFindRepoByAnnotation() {
+
+		ObjectRepository<AnnotatedItem> itemRepo = db.repository(AnnotatedItem.class).get();
+		assertTrue(itemRepo.isOpen());
+		itemRepo.close();
+	}
+	
+	
+	@Test
+	public void testFindRepoByAnnoWithKey( ) { 
+ 
+		ObjectRepository<AnnotatedItem> annoRepo = db.repository(AnnotatedItem.class).get() ; 
+		ObjectRepository<AnnotatedItem> annoRepo2 = db.repository(AnnotatedItem.class).hasKey("theKey").get() ; 
+		ObjectRepository<AnnotatedItem> annoRepo3 = db.repository(AnnotatedItem.class).hasKey("theKey2").get() ; 
+		
+		assertTrue(annoRepo.isOpen());
+		assertTrue(annoRepo2.isOpen());
+		assertTrue(annoRepo3.isOpen());
+		
+		
+		assertNotSame(annoRepo, annoRepo2);
+		assertNotSame(annoRepo2, annoRepo3);
+		assertNotSame(annoRepo, annoRepo3);
+		
+		
+		annoRepo.close();
+		annoRepo2.close();
+		annoRepo3.close();
+	}
+	
+	@Test
+	public void testFindRepoByAnnoWithKeyAndInvalidId() { 
+		ObjectRepository<AnnotatedItem> annoRepo = db.repository(AnnotatedItem.class).hasKey("theKey").get() ; 
+		
+		assertTrue(annoRepo.isOpen()) ; 
+		
+		
+		assertThrows(InvalidIdException.class,()->db.repository(AnnotatedItem.class).hasKey("theKey").withTypeId("itemName").get()) ; 
+		annoRepo.close();
+	}
+
+	@Test
+	public void testFindRepoWithInvalidAnnotations() { 
+		
+		ObjectRepository<InvalidAnnotatedItem> itemRepo = db.repository(InvalidAnnotatedItem.class).withTypeId("id").get() ; 
+		assertTrue(itemRepo.isOpen()) ; 
+		
+		assertThrows(NotIdentifiableException.class, ()->db.repository(InvalidAnnotatedItem.class).get()) ; 
+		itemRepo.close(); 
+	}
+	
+	@Test
+	public void testFindRepoByClientWhenCachedByConv() {
+
+		ObjectRepository<Item> itemRepoByConv = db.repository(Item.class).get();
+
+
+		assertTrue(itemRepoByConv.isOpen());
+
+		assertSame(itemRepoByConv, db.repository(Item.class).withTypeId("id").get());
+
+		assertThrows(InvalidIdException.class, () -> {
+			db.repository(Item.class).withTypeId("itemName").get();
+
+		});
+		itemRepoByConv.close();
+	}
+
+	@Test
+	public void testFindRepoByClientWhenCachedByClient() {
+		ObjectRepository<Item> itemRepoByClient = db.repository(Item.class).withTypeId("id").get();
+
+		assertTrue(itemRepoByClient.isOpen());
+		assertTrue(itemRepoByClient.getAttributes().get(RepositoryAttributes.ID_FIELD_NAME).equals("id"));
+
+		assertSame(itemRepoByClient, db.repository(Item.class).withTypeId("id").get());
+
+		assertThrows(InvalidIdException.class, () -> {
+
+			db.repository(Item.class).withTypeId("itemName").get();
+
+		});
+
+		itemRepoByClient.close();
+
+	}
+
+	@Test
+	public void testFindRepoByClientWhereCashedByAnnotation() {
+
+		ObjectRepository<AnnotatedItem> itemRepoByClient = db.repository(AnnotatedItem.class).get();
+		assertTrue(itemRepoByClient.isOpen());
+
+		assertSame(itemRepoByClient, db.repository(AnnotatedItem.class).withTypeId("id").get());
+		assertThrows(InvalidIdException.class, () -> {
+			db.repository(AnnotatedItem.class).withTypeId("itemName").get();
+		});
+
+	}
+
+	@Test
+	public void testFindRepoByConvWhereCachedByConv() {
+		ObjectRepository<Item> itemRepoByConv = db.repository(Item.class).get();
+		assertTrue(itemRepoByConv.isOpen());
+
+		assertSame(itemRepoByConv, db.repository(Item.class).get());
+		itemRepoByConv.close();
+	}
+
+	@Test
+	public void testFindRepoByConvWhereCashedByClient() {
+
+		ObjectRepository<Item> itemRepoByClient = db.repository(Item.class).withTypeId("itemName").get();
+		assertTrue(itemRepoByClient.isOpen());
+		assertTrue(itemRepoByClient.getAttributes().get(RepositoryAttributes.ID_FIELD_NAME).equals("itemName"));
+		//assertTrue(itemRepoByClient.getAttributes().get(RepositoryAttributes.ID_RECOGNITION_STRATEGY)
+			//	.equals(IdRecognitionStrategy.BY_CLIENT.toString()));
+
+		assertThrows(InvalidIdException.class, () -> {
+			db.repository(Item.class).get();
+		});
+
+		itemRepoByClient.close();
+	}
+
+	@Test
+	public void testFindRepoByConvWhereCashedByClient2() {
+
+		ObjectRepository<Item> repoByClient = db.repository(Item.class).withTypeId("id").get();
+
+		assertTrue(repoByClient.isOpen());
+		assertTrue(repoByClient.getAttributes().get(RepositoryAttributes.ID_FIELD_NAME).equals("id"));
+
+		assertSame(repoByClient, db.repository(Item.class).get());
+		repoByClient.close();
+	}
+ 
+	@Test
+	public void testFindRepoByAnnoWhenCachedByAnno() { 
+		ObjectRepository<AnnotatedItem> repoByAnno = db.repository(AnnotatedItem.class).get() ; 
+		assertSame(repoByAnno, db.repository(AnnotatedItem.class).get());
+		repoByAnno.close();
+		
+	}
+	@Test
+	public void testFindRepoByAnnoWhenCachedByClient() { 
+		
+		ObjectRepository<AnnotatedItem> repoByClient = db.repository(AnnotatedItem.class).withTypeId("id").get() ; 
+		
+		assertSame(repoByClient, db.repository(AnnotatedItem.class).get());
+		repoByClient.close();
+		
+		
+	}
+
+	@Test
+	public void testFindRepoByAnnoWhenCachedByClient2() { 
+		ObjectRepository<AnnotatedItem> repoByClient  = db.repository(AnnotatedItem.class).withTypeId("itemName").get() ; 
+		
+		assertTrue(repoByClient.isOpen());
+		assertThrows(InvalidIdException.class, ()->{
+			db.repository(AnnotatedItem.class).get() ; 
+		});
+		repoByClient.close();
+		
+	}
+	
+	
+	
+
+
+	@Test
+	public void testCachedRepoWithKey() {
+
+		ObjectRepository<Item> repoByImplictId = db.repository(Item.class).hasKey("test").get();
+
+
+		assertTrue(repoByImplictId.isOpen());
+
+		ObjectRepository<Item> repoByClient = db.repository(Item.class).hasKey("test").withTypeId("id").get();
+
+
+		assertSame(repoByImplictId, repoByClient);
+		repoByImplictId.close();
+
+	}
+
+
+
+
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	private static class AnnotatedItem implements Serializable {
+
+		@Id
+		private Integer id;
+
+		private String itemName;
+		private String repoKey;
+
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	private static class Item implements Serializable {
+
+		private Integer id;
+
+		private String itemName;
+		private String repoKey;
+
+
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	private static class NotIdentifiableItem implements Serializable { 
+		
+		private Integer theId ; 
+		private String itemName ; 
+		private String repoKey ; 
+		
+	}
+	
+	
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Entity
+	private static class InvalidAnnotatedItem implements Serializable { 
+		
+		@Id
+		private Integer id ; 
+		
+		@Id
+		private String itemName ; 
+		
+		private String repoKey ; 
+	}
+}


### PR DESCRIPTION
**Problem:**

suppose we working with multi-module  app (e.g. OSGI app)  where models are resides into separated jar file  and we could not add annotations to this models or even make a dependency between these models and  the nitrite API furthermore the nitrite repositories requires models to be identifiable in order to operate properly . 
So we need an alternative way to collect models meta-data  (e.g. id ,indices , collection name , ... ) during initializing a repository.

**Solution:**   
Nitrite API should expose a new method that allow client code to parameterize the request of new repository , and thus client code can pass model id or any other optional parameters .

**Example:**

```
// item and skill types imported from separated jar file 
public class GameStorageLocator { 
 
private Nitrite db ; 

public ObjectRepository<Item> gameItems() { 
    return db.repository(Item.class)
                  .hasKey("game-items")
                  .withTypeId("itemId")
                 .get() ; 
}

public ObjectRepository<Skill> gameSkills() { 
    return db.repository(Skill.class)
                  .hasKey("game-skills")
                 .withTypeId("skillId")
                 .get();
}

}
```