### PR TITLE
Add mapper using kotlinx serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <commons-io.version>2.11.0</commons-io.version>
         <kotlin.version>1.9.0</kotlin.version>
+        <kotlinx-serialization.version>1.5.1</kotlinx-serialization.version>
         <lombok.version>1.18.28</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <junit.version>4.13.2</junit.version>
@@ -100,6 +101,11 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-reflect</artifactId>
                 <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-serialization-json</artifactId>
+                <version>${kotlinx-serialization.version}</version>
             </dependency>
 
             <!-- Commons Dependencies -->
@@ -401,6 +407,27 @@
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${kotlin.version}</version>
                     <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <id>compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <compilerPlugins>
+                            <plugin>kotlinx-serialization</plugin>
+                        </compilerPlugins>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jetbrains.kotlin</groupId>
+                            <artifactId>kotlin-maven-serialization</artifactId>
+                            <version>${kotlin.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.jetbrains.dokka</groupId>

--- a/potassium-nitrite/pom.xml
+++ b/potassium-nitrite/pom.xml
@@ -104,6 +104,10 @@
             <artifactId>snakeyaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-serialization-json</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/Builder.kt
+++ b/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/Builder.kt
@@ -19,6 +19,7 @@ package org.dizitart.kno2
 import org.dizitart.no2.Nitrite
 import org.dizitart.no2.NitriteBuilder
 import org.dizitart.no2.NitriteConfig
+import org.dizitart.no2.common.mapper.NitriteMapper
 import org.dizitart.no2.common.module.NitriteModule
 import org.dizitart.no2.common.module.NitriteModule.module
 import org.dizitart.no2.spatial.SpatialIndexer
@@ -57,7 +58,7 @@ class Builder internal constructor() {
     }
 
     private fun loadDefaultPlugins(builder: NitriteBuilder) {
-        val mapperFound = modules.any { module -> module.plugins().any { it is KNO2JacksonMapper } }
+        val mapperFound = modules.any { module -> module.plugins().any { it is NitriteMapper } }
         val spatialIndexerFound = modules.any { module -> module.plugins().any { it is SpatialIndexer } }
 
         if (!mapperFound && spatialIndexerFound) {

--- a/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/DocumentDecoder.kt
+++ b/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/DocumentDecoder.kt
@@ -1,0 +1,230 @@
+package org.dizitart.kno2.kotlinxserialization
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SealedClassSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.findPolymorphicSerializer
+import kotlinx.serialization.internal.AbstractPolymorphicSerializer
+import kotlinx.serialization.internal.NamedValueDecoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import org.dizitart.kno2.isEmpty
+import org.dizitart.no2.collection.Document
+
+/**
+ * @author Joris Jensen
+ * @since 4.2.0
+ */
+@OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+internal class DocumentDecoder(private val document: Document, descriptor: SerialDescriptor) :
+    NamedValueDecoder() {
+    private var currentIndex = 0
+    private val isCollection = descriptor.kind == StructureKind.LIST || descriptor.kind == StructureKind.MAP
+    private val size = if (isCollection) Int.MAX_VALUE else descriptor.elementsCount
+    override fun decodeTaggedValue(tag: String): Any = document[tag]
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        while (currentIndex < size) {
+            val name = descriptor.getTag(currentIndex++)
+            if (document.containsKey(name)) return currentIndex - 1
+            if (isCollection) {
+                // if document does not contain key we look for, then indices in collection have ended
+                break
+            }
+        }
+        return CompositeDecoder.DECODE_DONE
+    }
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int =
+        descriptor.elementsCount
+
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (deserializer is AbstractPolymorphicSerializer<*>) {
+            val type = document.get(nested("type"))?.toString()
+            val actualSerializer: DeserializationStrategy<Any> = deserializer.findPolymorphicSerializer(this, type)
+
+            @Suppress("UNCHECKED_CAST")
+            return actualSerializer.deserialize(this) as T
+        }
+
+        return deserializer.deserialize(this)
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        currentTagOrNull?.let {
+            val fieldValue = document[it]
+                ?: throw SerializationException("parameter $it should be of type Document, but is null")
+            val exceptionMessage = "parameter $it should be of type ${Document::class}, but is ${fieldValue::class}"
+            when (descriptor.kind) {
+                StructureKind.CLASS, StructureKind.OBJECT -> {
+                    val innerDocument = fieldValue as? Document
+                        ?: throw SerializationException(exceptionMessage)
+                    return DocumentDecoder(innerDocument, descriptor)
+                }
+
+                StructureKind.MAP -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val innerMap = fieldValue as? Map<Any, Any>
+                        ?: throw SerializationException(exceptionMessage)
+                    return MapDecoder(innerMap.toMutableMap())
+                }
+
+                StructureKind.LIST -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val innerList = fieldValue as? Collection<Any>
+                        ?: throw SerializationException(exceptionMessage)
+                    return ListDecoder(ArrayDeque(innerList))
+                }
+
+                else -> {}
+            }
+        }
+        return super.beginStructure(descriptor)
+    }
+
+    override fun decodeNotNullMark(): Boolean =
+        currentTagOrNull != null && document.containsKey(currentTag) && document[currentTag] != null
+
+    override fun decodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor): Int =
+        when (val taggedValue = document.get(tag)) {
+            is Int -> taggedValue
+            is String -> enumDescriptor.getElementIndex(taggedValue)
+                .also { if (it == CompositeDecoder.UNKNOWN_NAME) throw SerializationException("Enum '${enumDescriptor.serialName}' does not contain element with name '$taggedValue'") }
+
+            else -> throw SerializationException("Value of enum entry '$tag' is neither an Int nor a String")
+        }
+
+    companion object {
+        fun <T : Any> decodeFromDocument(source: Document, type: Class<T>) =
+            type.kotlin.serializer().run {
+                if (source.isEmpty()) {
+                    deserialize(EmptyDecoder(descriptor))
+                } else {
+                    deserialize(DocumentDecoder(source, descriptor))
+                }
+            }
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class ListDecoder(private val list: ArrayDeque<Any>) : AbstractDecoder() {
+    private var elementIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun decodeValue(): Any = list.removeFirst()
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        if (list.isEmpty() || elementIndex == descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
+        return elementIndex++
+    }
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = descriptor.elementsCount
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        if (descriptor.kind == StructureKind.CLASS || descriptor.kind == StructureKind.OBJECT || descriptor.kind == StructureKind.MAP) {
+            if (list.isEmpty()) {
+                return ListDecoder(list)
+            }
+            val fieldValue = list.removeFirst()
+            val innerDocument = fieldValue as? Document
+                ?: throw SerializationException("element should be of type ${Document::class}, but is ${fieldValue::class}")
+            return DocumentDecoder(innerDocument, descriptor)
+        }
+        return ListDecoder(list)
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class MapDecoder(map: MutableMap<Any, Any>) : AbstractDecoder() {
+    val mapEntries = ArrayDeque(map.entries)
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+    private var elementIndex = 0
+    lateinit var currentEntry: Pair<Any, Any>
+
+    override fun decodeValue(): Any = if (elementIndex % 2 == 1) {
+        currentEntry = mapEntries.removeFirst().toPair()
+        currentEntry.first
+    } else {
+        currentEntry.second
+    }
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        if (mapEntries.isEmpty() && elementIndex % 2 == 0) return CompositeDecoder.DECODE_DONE
+        return elementIndex++
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class EmptyDecoder(descriptor: SerialDescriptor) : Decoder, CompositeDecoder {
+    var index = descriptor.elementsCount - 1
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean = decodeBoolean()
+    override fun decodeByteElement(descriptor: SerialDescriptor, index: Int): Byte = decodeByte()
+    override fun decodeCharElement(descriptor: SerialDescriptor, index: Int): Char = decodeChar()
+    override fun decodeDoubleElement(descriptor: SerialDescriptor, index: Int): Double = decodeDouble()
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = when (descriptor.kind) {
+        StructureKind.LIST,
+        StructureKind.MAP -> CompositeDecoder.DECODE_DONE
+        else -> index--
+    }
+
+    override fun decodeFloatElement(descriptor: SerialDescriptor, index: Int): Float = decodeFloat()
+    override fun decodeInlineElement(descriptor: SerialDescriptor, index: Int): Decoder = decodeInline(descriptor)
+    override fun decodeIntElement(descriptor: SerialDescriptor, index: Int): Int = decodeInt()
+    override fun decodeLongElement(descriptor: SerialDescriptor, index: Int): Long = decodeLong()
+
+    override fun <T : Any> decodeNullableSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T?>,
+        previousValue: T?
+    ): T? = null
+
+    @OptIn(InternalSerializationApi::class)
+    override fun <T> decodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T>,
+        previousValue: T?
+    ): T = when (deserializer) {
+        is SealedClassSerializer -> deserializer.baseClass.sealedSubclasses.first().serializer()
+            .deserialize(EmptyDecoder(descriptor))
+
+        else -> decodeSerializableValue(deserializer)
+    }
+
+    override fun decodeShortElement(descriptor: SerialDescriptor, index: Int): Short = decodeShort()
+
+    override fun decodeStringElement(descriptor: SerialDescriptor, index: Int): String = decodeString()
+
+    override fun endStructure(descriptor: SerialDescriptor) {}
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder = EmptyDecoder(descriptor)
+
+    override fun decodeBoolean(): Boolean = true
+    override fun decodeByte(): Byte = 0
+    override fun decodeShort(): Short = 0
+    override fun decodeInt(): Int = 0
+    override fun decodeLong(): Long = 0
+    override fun decodeFloat(): Float = 0f
+    override fun decodeDouble(): Double = 0.0
+    override fun decodeChar(): Char = '0'
+    override fun decodeString(): String = ""
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = 0
+
+    override fun decodeInline(descriptor: SerialDescriptor): Decoder = EmptyDecoder(descriptor)
+
+    override fun decodeNotNullMark(): Boolean = false
+
+    override fun decodeNull(): Nothing? = null
+}

--- a/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/DocumentEncoder.kt
+++ b/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/DocumentEncoder.kt
@@ -1,0 +1,128 @@
+package org.dizitart.kno2.kotlinxserialization
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.findPolymorphicSerializer
+import kotlinx.serialization.internal.AbstractPolymorphicSerializer
+import kotlinx.serialization.internal.TaggedEncoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import org.dizitart.no2.collection.Document
+import kotlin.reflect.full.starProjectedType
+
+/**
+ * @author Joris Jensen
+ * @since 4.2.0
+ */
+@OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+internal class DocumentEncoder(private val document: Document) : TaggedEncoder<String>() {
+    override fun encodeTaggedValue(tag: String, value: Any) {
+        document.put(tag, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        if (serializer is AbstractPolymorphicSerializer<*>) {
+            val casted = serializer as AbstractPolymorphicSerializer<Any>
+            val actualSerializer = casted.findPolymorphicSerializer(this, value as Any)
+            val innerDocument = Document.createDocument()
+            innerDocument.put("type", actualSerializer.descriptor.serialName)
+            document.put(currentTagOrNull, innerDocument)
+            return actualSerializer.serialize(DocumentEncoder(innerDocument), value)
+        }
+
+        return serializer.serialize(this, value)
+    }
+
+    override fun encodeTaggedNull(tag: String) {
+        document.put(tag, null)
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        currentTagOrNull?.let {
+            when (descriptor.kind) {
+                StructureKind.CLASS, StructureKind.OBJECT -> {
+                    val innerDocument = Document.createDocument()
+                    document.put(it, innerDocument)
+                    return DocumentEncoder(innerDocument)
+                }
+
+                StructureKind.MAP -> {
+                    val innerMap = mutableMapOf<Any, Any>()
+                    document.put(it, innerMap)
+                    return MapEncoder(innerMap)
+                }
+
+                StructureKind.LIST -> {
+                    val l = mutableListOf<Any>()
+                    document.put(it, l)
+                    return ListEncoder(l)
+                }
+
+                else -> {}
+            }
+        }
+        return super.beginStructure(descriptor)
+    }
+
+    override fun SerialDescriptor.getTag(index: Int): String = getElementName(index)
+
+    override fun encodeTaggedEnum(tag: String, enumDescriptor: SerialDescriptor, ordinal: Int) {
+        document.put(tag, enumDescriptor.getElementName(ordinal))
+    }
+
+    companion object {
+        fun <T : Any> encodeToDocument(value: T): Document =
+            Document.createDocument().also {
+                serializer(value::class.starProjectedType).serialize(DocumentEncoder(it), value)
+            }
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class ListEncoder(val list: MutableList<Any>) : AbstractEncoder() {
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun encodeValue(value: Any) {
+        list.add(value)
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        if (descriptor.kind == StructureKind.CLASS || descriptor.kind == StructureKind.OBJECT || descriptor.kind == StructureKind.MAP) {
+            val innerDocument = Document.createDocument()
+            list.add(innerDocument)
+            return DocumentEncoder(innerDocument)
+        }
+        return super.beginStructure(descriptor)
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class MapEncoder(val map: MutableMap<Any, Any>) : AbstractEncoder() {
+    var currentKey: Any? = null
+    var currentIndex = 0
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override fun encodeValue(value: Any) {
+        if (currentIndex % 2 == 0) {
+            currentKey = value
+        } else {
+            currentKey?.let {
+                map[it] = value
+            } ?: throw SerializationException("no key found for value $value")
+        }
+    }
+
+    override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+        currentIndex = index
+        return true
+    }
+}

--- a/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/KotlinXSerializationMapper.kt
+++ b/potassium-nitrite/src/main/kotlin/org/dizitart/kno2/kotlinxserialization/KotlinXSerializationMapper.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017-2020. Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dizitart.kno2.kotlinxserialization
+
+import org.dizitart.no2.NitriteConfig
+import org.dizitart.no2.collection.Document
+import org.dizitart.no2.collection.NitriteId
+import org.dizitart.no2.common.mapper.NitriteMapper
+import org.dizitart.no2.common.module.NitriteModule
+import org.dizitart.no2.common.module.NitritePlugin
+import org.dizitart.no2.exceptions.ObjectMappingException
+import java.util.Date
+
+/**
+ * Mapper using kotlinx.serialization
+ *
+ * @author Joris Jensen
+ * @since 4.2.0
+ */
+object KotlinXSerializationMapper : NitriteMapper, NitriteModule {
+    private fun <Target : Any> convertFromDocument(source: Document?, type: Class<Target>): Target? =
+        source?.let { DocumentDecoder.decodeFromDocument(source, type) }
+
+    private fun <Source : Any> convertToDocument(source: Source): Document = DocumentEncoder.encodeToDocument(source)
+
+    override fun <Source, Target : Any> tryConvert(source: Source, type: Class<Target>): Any? {
+        val nonNullSource = source ?: return null
+        return when {
+            isValueType(nonNullSource::class.java) -> source as Target
+            Document::class.java.isAssignableFrom(type) -> {
+                if (source is Document) {
+                    source
+                } else {
+                    convertToDocument(source)
+                }
+            }
+
+            source is Document -> convertFromDocument(source, type)
+            else -> throw ObjectMappingException("Can't convert object of type " + nonNullSource::class.java + " to type " + type)
+        }
+    }
+
+    private fun isValueType(type: Class<*>): Boolean {
+        if (type.isPrimitive && type != Void.TYPE) return true
+        if (valueTypes.contains(type)) return true
+        return valueTypes.any { it.isAssignableFrom(type) }
+    }
+
+    private val valueTypes: List<Class<*>> = listOf(
+        Number::class.java,
+        Boolean::class.java,
+        Character::class.java,
+        String::class.java,
+        Array<Byte>::class.java,
+        Enum::class.java,
+        NitriteId::class.java,
+        Date::class.java,
+    )
+
+    override fun plugins(): MutableSet<NitritePlugin> = mutableSetOf(KotlinXSerializationMapper)
+    override fun initialize(nitriteConfig: NitriteConfig) {}
+}

--- a/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/KotlinXSerializationMapperTest.kt
+++ b/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/KotlinXSerializationMapperTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2017-2020. Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dizitart.kno2
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertSame
+import kotlinx.serialization.Serializable
+import org.dizitart.kno2.kotlinxserialization.KotlinXSerializationMapper
+import org.dizitart.no2.collection.Document
+import org.dizitart.no2.mvstore.MVStoreModule
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ *
+ * @author Joris Jensen
+ */
+class KotlinXSerializationMapperTest {
+    private val dbPath = getRandomTempDbFile()
+
+    @Serializable
+    private data class TestData(
+        val polymorphType: SomePolymorphType,
+        val someMap: Map<String, String>,
+        val someSerializableObjectMap: Map<InnerObject, SomePolymorphType>,
+        val innerObject: InnerObject,
+        val id: String,
+        val valueClass: SomeValueClass,
+        val someInt: Int,
+        val someDouble: Double,
+        val nullable: String?,
+        val enum: SomeEnum,
+        val someList: List<TestData>,
+        val someArray: Array<String>,
+    ) {
+
+        @JvmInline
+        @Serializable
+        value class SomeValueClass(val s: String)
+
+        @Serializable
+        enum class SomeEnum {
+            SomeValue,
+        }
+
+        @Serializable
+        data class InnerObject(val someValue: String)
+
+        @Serializable
+        sealed class SomePolymorphType(val value: String) {
+            @Serializable
+            object SomeTypeA : SomePolymorphType("Type A")
+
+            @Serializable
+            data class SomeTypeB(val someValue: String) : SomePolymorphType("Type B")
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as TestData
+
+            if (polymorphType != other.polymorphType) return false
+            if (someMap != other.someMap) return false
+            if (innerObject != other.innerObject) return false
+            if (id != other.id) return false
+            if (someInt != other.someInt) return false
+            if (someDouble != other.someDouble) return false
+            if (nullable != other.nullable) return false
+            if (enum != other.enum) return false
+            if (someList != other.someList) return false
+            return someArray.contentEquals(other.someArray)
+        }
+
+        override fun hashCode(): Int {
+            var result = polymorphType.hashCode()
+            result = 31 * result + someMap.hashCode()
+            result = 31 * result + innerObject.hashCode()
+            result = 31 * result + id.hashCode()
+            result = 31 * result + someInt
+            result = 31 * result + someDouble.hashCode()
+            result = 31 * result + (nullable?.hashCode() ?: 0)
+            result = 31 * result + enum.hashCode()
+            result = 31 * result + someList.hashCode()
+            result = 31 * result + someArray.contentHashCode()
+            return result
+        }
+    }
+
+    private val testData = TestData(
+        TestData.SomePolymorphType.SomeTypeA,
+        someList = listOf(
+            TestData(
+                TestData.SomePolymorphType.SomeTypeB("someValue"),
+                emptyMap(),
+                emptyMap(),
+                TestData.InnerObject(""),
+                "",
+                TestData.SomeValueClass("someString"),
+                1,
+                1.0,
+                "test",
+                TestData.SomeEnum.SomeValue,
+                emptyList(),
+                emptyArray(),
+            ),
+        ),
+        valueClass = TestData.SomeValueClass("someString"),
+        someArray = arrayOf("someArrayData"),
+        id = "testId",
+        someInt = 1,
+        someDouble = 1.0,
+        innerObject = TestData.InnerObject("someValue"),
+        nullable = null,
+        enum = TestData.SomeEnum.SomeValue,
+        someMap = mapOf("testkey" to "testvalue", "test1" to "test2"),
+        someSerializableObjectMap = mapOf(TestData.InnerObject("test") to TestData.SomePolymorphType.SomeTypeA)
+    )
+
+    @Test
+    fun testModule() {
+        val db = nitrite {
+            loadModule(MVStoreModule(dbPath))
+            loadModule(KotlinXSerializationMapper)
+        }
+
+        val repo = db.getRepository<TestData>()
+        repo.insert(testData)
+        repo.find { a -> a.second.get("id") == testData.id }.firstOrNull().also {
+            assertEquals(it, testData)
+        }
+        db.close()
+        Files.delete(Paths.get(dbPath))
+    }
+
+    @Test
+    fun testMapping() {
+        val document = KotlinXSerializationMapper.tryConvert(testData, Document::class.java)
+        val decodedObject = KotlinXSerializationMapper.tryConvert(document, TestData::class.java) as TestData
+        assertSame(testData.someArray.size, decodedObject.someArray.size)
+        testData.someArray.forEachIndexed { index, s -> assertEquals(decodedObject.someArray[index], s) }
+        assertEquals(testData, decodedObject.copy(someArray = testData.someArray))
+    }
+}


### PR DESCRIPTION
This pull request adds a new mapper that uses [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) instead of jackson.