### PR TITLE
fix behavior when updating values where the value was previously null

### DIFF
--- a/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
@@ -176,8 +176,14 @@ class NitriteDocument extends LinkedHashMap<String, Object> implements Document 
                     // if the value is a document, merge it recursively
                     if (containsKey(key)) {
                         // if the current document already contains the key,
-                        // then merge the embedded document
-                        get(key, Document.class).merge((Document) value);
+                        // and the value is not null, merge it
+                        Document pairs = get(key, Document.class);
+                        if (pairs != null) {
+                            pairs.merge((Document) value);
+                        } else {
+                            //otherwise, just set the value to whatever was provided
+                            put(key, value);
+                        }
                     } else {
                         // if the current document does not contain the key,
                         // then put the embedded document as it is

--- a/nitrite/src/test/java/org/dizitart/no2/integration/collection/CollectionUpdateTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/integration/collection/CollectionUpdateTest.java
@@ -17,10 +17,7 @@
 
 package org.dizitart.no2.integration.collection;
 
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.DocumentCursor;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.collection.UpdateOptions;
+import org.dizitart.no2.collection.*;
 import org.dizitart.no2.common.WriteResult;
 import org.dizitart.no2.exceptions.NitriteIOException;
 import org.dizitart.no2.exceptions.NotIdentifiableException;
@@ -298,5 +295,19 @@ public class CollectionUpdateTest extends BaseCollectionTest {
         coll.update(doc3);
 
         assertEquals(coll.find(where("fruit").eq("Apple")).size(), 1);
+    }
+
+    @Test
+    public void testUpdatePreviouslyNullObject() {
+        Document doc1 = createDocument().put("fruitType", null);
+        NitriteCollection coll = db.getCollection("test");
+
+        WriteResult insert = coll.insert(doc1);
+        NitriteId next = insert.iterator().next();
+        Document doc2 = createDocument().put("_id", next.getIdValue()).put("fruitType", createDocument().put("family", "citric"));
+        coll.update(doc2);
+
+        assertEquals(coll.find(where("_id").eq(next.getIdValue())).size(), 1);
+        assertNotNull(coll.find(where("_id").eq(next.getIdValue())).firstOrNull().get("fruitType"));
     }
 }


### PR DESCRIPTION
## Context

When trying to update nested documents, if the value was previously null, a NPE was raised. This was because the code inside `NitriteDocument::merge` wasn't null checking the value after taking it out of the map. 

## Fix

Added a null check. If the value returned from `get` is `null`, I assumed we should follow the default behavior and just replace it with whatever was provided by the method. If not, we then use `merge`.  While fixing this bug I noticed that there's no unit tests for `NitriteDocument::merge` but they are covered indirectly via the `CollectionUpdateTest`. I added a new test case to the existing suite. 

The code works but I'm up for comments - I'm not sure about the full implications of doing this fix so LMK if there's something I should fix or do differently :) 