### PR TITLE
Add support to ignore field separator

### DIFF
--- a/nitrite/src/main/java/org/dizitart/no2/collection/Document.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/Document.java
@@ -100,6 +100,19 @@ public interface Document extends Iterable<Pair<String, Object>>, Cloneable, Ser
     Document put(final String key, final Object value);
 
     /**
+     * Associates the specified value with the specified key in this document.
+     * <p>
+     * NOTE: An embedded field is also supported.
+     * </p>
+     *
+     * @param key                  the key
+     * @param value                the value
+     * @param ignoreFieldSeparator if set to {@code true}, it will ignore the field separator
+     * @return the document
+     */
+    Document put(final String key, final Object value, boolean ignoreFieldSeparator);
+
+    /**
      * Returns the value to which the specified key is associated with,
      * or null if this document contains no mapping for the key.
      *

--- a/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
@@ -38,9 +38,8 @@ import static org.dizitart.no2.common.util.StringUtils.isNullOrEmpty;
 import static org.dizitart.no2.common.util.ValidationUtils.notNull;
 
 /**
- *
- * @since 4.0
  * @author Anindya Chatterjee
+ * @since 4.0
  */
 class NitriteDocument extends LinkedHashMap<String, Object> implements Document {
     private static final long serialVersionUID = 1477462374L;
@@ -54,8 +53,7 @@ class NitriteDocument extends LinkedHashMap<String, Object> implements Document 
         super(objectMap);
     }
 
-    @Override
-    public Document put(String field, Object value) {
+    private static void validateField(String field, Object value) {
         // field name cannot be empty or null
         if (isNullOrEmpty(field)) {
             throw new InvalidOperationException("Document does not support empty or null key");
@@ -71,6 +69,21 @@ class NitriteDocument extends LinkedHashMap<String, Object> implements Document 
             throw new ValidationException("Type " + value.getClass().getName()
                 + " does not implement java.io.Serializable");
         }
+    }
+
+    @Override
+    public Document put(String key, Object value, boolean ignoreFieldSeparator) {
+        if (ignoreFieldSeparator) {
+            super.put(key, value);
+            return this;
+        } else {
+            return put(key, value);
+        }
+    }
+
+    @Override
+    public Document put(String field, Object value) {
+        validateField(field, value);
 
         // if field name contains field separator, split the fields, and put the value
         // accordingly associated with th embedded field.


### PR DESCRIPTION
At the moment, there is no way to ignore field separator. This pr is adding a new put method to do so.

This behavior is primary to the PackageSearch team, allowing custom documents to be directly associated with the key.
