### PR TITLE
POM changes to fix build for contributors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B -ff -ntp clean install -Dgpg.skip=true
+        run: mvn -B -ff -ntp clean install
 
       - name: Publish Code Coverage
         if: github.ref == 'refs/heads/main' && matrix.java == '11'
@@ -70,7 +70,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B -ff -ntp clean install -Dgpg.skip=true
+        run: mvn -B -ff -ntp clean install
 
   build_windows:
     runs-on: windows-latest
@@ -93,7 +93,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B -ff -ntp clean install --% -Dgpg.skip=true
+        run: mvn -B -ff -ntp clean install --%
 
   verify-native:
     name: Verify GraalVM ${{ matrix.java }} compatibility on ${{ matrix.os }}
@@ -111,7 +111,7 @@ jobs:
           distribution: 'graalvm-community'
 
       - name: Install nitrite
-        run: mvn -B -ff -ntp clean install "-Dgpg.skip=true" -DskipTests
+        run: mvn -B -ff -ntp clean install -DskipTests
 
       - name: Run native tests
         working-directory: ./nitrite-native-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B -ff -ntp clean install --%
+        run: mvn -B -ff -ntp clean install
 
   verify-native:
     name: Verify GraalVM ${{ matrix.java }} compatibility on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}
 
       - name: Deploy Release
-        run: mvn -B -ff -ntp deploy -DskipTests -Dgpg.passphrase="$PGP_KEY_PASSWORD"
+        run: mvn -P deploy -B -ff -ntp deploy -DskipTests -Dgpg.passphrase="$PGP_KEY_PASSWORD"
         shell: bash
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USER }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -51,7 +51,7 @@ jobs:
           PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}
 
       - name: Deploy Snapshot
-        run: mvn -B -ff -ntp deploy -DskipTests -Dgpg.passphrase="$PGP_KEY_PASSWORD"
+        run: mvn -P deploy -B -ff -ntp  deploy -DskipTests -Dgpg.passphrase="$PGP_KEY_PASSWORD"
         shell: bash
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USER }}

--- a/nitrite-bom/pom.xml
+++ b/nitrite-bom/pom.xml
@@ -67,17 +67,4 @@
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/nitrite-jackson-mapper/pom.xml
+++ b/nitrite-jackson-mapper/pom.xml
@@ -133,16 +133,8 @@
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/nitrite-mvstore-adapter/pom.xml
+++ b/nitrite-mvstore-adapter/pom.xml
@@ -176,14 +176,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive combine.children="append">

--- a/nitrite-rocksdb-adapter/pom.xml
+++ b/nitrite-rocksdb-adapter/pom.xml
@@ -174,14 +174,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive combine.children="append">

--- a/nitrite-spatial/pom.xml
+++ b/nitrite-spatial/pom.xml
@@ -118,10 +118,6 @@
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>

--- a/nitrite-support/pom.xml
+++ b/nitrite-support/pom.xml
@@ -127,14 +127,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive combine.children="append">

--- a/nitrite/pom.xml
+++ b/nitrite/pom.xml
@@ -207,16 +207,8 @@
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,9 @@
         <guava.version>33.3.1-jre</guava.version>
         <threetenbp.version>1.7.0</threetenbp.version>
 
-        <error-prone.version>2.36.0</error-prone.version>
+        <!-- Error Prone version > 2.31.0 can't run on JDK 11. see https://errorprone.info/docs/installation -->
+        <error-prone.version>2.31.0</error-prone.version>
+
         <jacoco.version>0.8.12</jacoco.version>
         <surefire.version>3.5.2</surefire.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -522,18 +522,30 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+            <activation>
+                <!-- "true" to maintain existing behavior until CI jobs, etc. add "-P release" to the mvn args -->
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+    </profiles>
 
     <distributionManagement>
         <!-- Repository for snapshots -->

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>deploy</id>
             <build>
                 <plugins>
                     <plugin>
@@ -541,10 +541,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <activation>
-                <!-- "true" to maintain existing behavior until CI jobs, etc. add "-P release" to the mvn args -->
-                <activeByDefault>true</activeByDefault>
-            </activation>
         </profile>
 
     </profiles>

--- a/potassium-nitrite/pom.xml
+++ b/potassium-nitrite/pom.xml
@@ -164,14 +164,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive combine.children="append">


### PR DESCRIPTION
Hi @anidotnet , I already have what appears to be a working fix for #1079, but as a first step to prepare for that, I offer a proposed changes to the build setup. **Basically, most people trying to follow the simple instructions in `README.md` to clone and build the project would get an error.** Currently, `mvn clean install` requires `gpg` to be installed for the gpg signing step to run successfully.

I was reading between the lines here to try to understand your intention, but I think that the configuration of the BOM module makes it very clear. Since a BOM can't truly require any meaningful build steps, the only reason to have `maven-gpg-plugin` and `nexus-staging-maven-plugin` there is if those are used to sign and push the actual release artifacts. If that's correct, then the traditional and recommended way to structure this within Maven is to set it up as a "profile". I put it in the parent POM and named it as "release". Then as a next step, the Github Actions config files can be updated from `mvn ... deploy` to `mvn -P release ... deploy`. (NOTE: now that I look more closely at those configs, I see the existing workaround was just `-Dgpg.skip=true`. 😅 As I now see there is a workaround, I will no longer treat this PR as a dependency of the fix for #1079 🙏 )

In order to not break any existing setups, I temporarily configured the `release` profile to be ON by default, but this still provides the benefit that now someone without gpg installed on their machine can build the project successfully by disabling the release profile. (That can either be set in the IDE, as in this screenshot below, or using command line flags, e.g. `mvn -P '!release' <target>`)
<img src="https://github.com/user-attachments/assets/2cb4e618-ec95-480d-81fa-a1647a313266" width=250/>

----

The other commit in this PR is a simple version change of the error-prone plugin library. In the README file, it says:
> To build and test Nitrite, ensure you have JDK 11 (or higher) and Maven 3 installed.

However, the given version of the error-prone plugin fails at runtime with an `Unsupported class file major version 61` error, which means it requires JDK 17, actually. You can of course tell me whether you want to hold back the error-prone version or if we should just update the README to say 
> ... ensure you have JDK 17 (or higher) ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Downgraded the `error-prone` dependency to ensure compatibility with JDK 11.

- **Chores**
	- Removed the `maven-gpg-plugin` and `nexus-staging-maven-plugin` from multiple projects, simplifying the build process.
	- Introduced a new profile for release management in the main `pom.xml`.
	- Updated deployment commands in workflow files to utilize the new profile for deployment processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->