### PR TITLE
WIP geodetic distance search

### DIFF
--- a/nitrite-spatial/pom.xml
+++ b/nitrite-spatial/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>jts-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.sf.geographiclib</groupId>
+            <artifactId>GeographicLib-Java</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/GeometricShapeFactoryExt.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/GeometricShapeFactoryExt.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-package org.locationtech.jts.util;
+package org.dizitart.no2.spatial;
 
 import net.sf.geographiclib.Geodesic;
 import net.sf.geographiclib.GeodesicData;
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.util.GeometricShapeFactory;
 
 /** Extends the JTS GeometricShapeFactory to add geodetic "small circle" geometry. */
 public class GeometricShapeFactoryExt extends GeometricShapeFactory {

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
@@ -19,7 +19,7 @@ package org.dizitart.no2.spatial;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.util.GeometricShapeFactory;
+import org.locationtech.jts.util.GeometricShapeFactoryExt;
 
 /**
  * @since 4.0
@@ -35,7 +35,7 @@ class NearFilter extends WithinFilter {
     }
 
     private static Geometry createCircle(Coordinate center, double radius) {
-        GeometricShapeFactory shapeFactory = new GeometricShapeFactory();
+        GeometricShapeFactoryExt shapeFactory = new GeometricShapeFactoryExt();
         shapeFactory.setNumPoints(64);
         shapeFactory.setCentre(center);
         shapeFactory.setSize(radius * 2);

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
@@ -73,10 +73,18 @@ class NearFilter extends IntersectsFilter implements FlattenableFilter {
     @Override
     public List<Filter> getFilters() {
         return List.of(
+            // [PR note] Use of "IntersectsFilter" was an arbitrary choice. Any of the misbehaving filters that
+            //   are really just doing a bounding box test within the spatial index would have worked.
+            //   The important thing for now was to not accidentally produce *recursive* flattening, and at the
+            //   time I wrote this line, I was still planning to edit WithinFilter to have it also implement
+            //   the FlattenableFilter interface
             new IntersectsFilter(getField(), getValue()),
             new NonIndexNearFilter(getField(), getValue()));
     }
 
+    // [PR note] This is probably the first time in years I've used a non-static inner class. I think we
+    //    should prefer to avoid the pattern in the final code, but it saved some boiler-plate here for the
+    //    proof-of-concept.
     public class NonIndexNearFilter extends FieldBasedFilter {
 
         protected NonIndexNearFilter(String field, Geometry circle) {

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/NearFilter.java
@@ -19,7 +19,6 @@ package org.dizitart.no2.spatial;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.util.GeometricShapeFactoryExt;
 
 /**
  * @since 4.0

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/SpatialFluentFilter.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/SpatialFluentFilter.java
@@ -89,6 +89,7 @@ public class SpatialFluentFilter {
      * @return the new {@link Filter} instance
      */
     public Filter near(Point point, Double distance) {
+//        return new NearFilter(field, point, distance);
         return new NearFilter(field, point, distance);
     }
 }

--- a/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/WithinFilter.java
+++ b/nitrite-spatial/src/main/java/org/dizitart/no2/spatial/WithinFilter.java
@@ -16,10 +16,18 @@
 
 package org.dizitart.no2.spatial;
 
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteId;
+import org.dizitart.no2.common.tuples.Pair;
+import org.dizitart.no2.exceptions.FilterException;
+import org.dizitart.no2.filters.FieldBasedFilter;
 import org.dizitart.no2.index.IndexMap;
 import org.locationtech.jts.geom.Geometry;
 
 import java.util.List;
+import java.util.regex.Matcher;
+
+import static org.dizitart.no2.common.util.Numbers.compare;
 
 /**
  * @since 4.0
@@ -40,4 +48,5 @@ class WithinFilter extends SpatialFilter {
     public String toString() {
         return "(" + getField() + " within " + getValue() + ")";
     }
+
 }

--- a/nitrite-spatial/src/main/java/org/locationtech/jts/util/GeometricShapeFactoryExt.java
+++ b/nitrite-spatial/src/main/java/org/locationtech/jts/util/GeometricShapeFactoryExt.java
@@ -1,0 +1,45 @@
+package org.locationtech.jts.util;
+
+import net.sf.geographiclib.Geodesic;
+import net.sf.geographiclib.GeodesicData;
+import net.sf.geographiclib.GeodesicMask;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+
+/** Extends the JTS GeometricShapeFactory to add geodetic "small circle" geometry. */
+public class GeometricShapeFactoryExt extends GeometricShapeFactory {
+
+    /**
+     * Bitmask specifying which results should be returned from the "direct" calculation.
+     * We don't need to know the azimuth at s2, so we can save a couple of CPU cycles by not asking for it!
+     * <p/>
+     * See javadoc at {@link Geodesic#Direct(double, double, double, double, int)} for more details.
+     */
+    public static final int OUTMASK = GeodesicMask.STANDARD ^ GeodesicMask.AZIMUTH;
+
+    @Override
+    public Polygon createCircle()
+    {
+        Envelope env = dim.getEnvelope();
+        double radiusInMeters = env.getWidth() / 2.0;
+        double ctrX = dim.getCentre().x;
+        double ctrY = dim.getCentre().y;
+
+        Coordinate[] pts = new Coordinate[nPts + 1];
+        int i;
+        for (i = 0; i < nPts; i++) {
+            // because this is the "azimuth" value, it starts at "geodetic north" and proceeds clockwise
+            double azimuthInDegrees = i * (360.0 / nPts);
+            GeodesicData directResult = Geodesic.WGS84.Direct(ctrX, ctrY, azimuthInDegrees, radiusInMeters, OUTMASK);
+            double lat = directResult.lat2;
+            double lon = directResult.lon2;
+            pts[i] = coord(lat, lon);
+        }
+        pts[i] = new Coordinate(pts[0]);
+
+        LinearRing ring = geomFact.createLinearRing(pts);
+        return geomFact.createPolygon(ring);
+    }
+}

--- a/nitrite-spatial/src/main/java/org/locationtech/jts/util/GeometricShapeFactoryExt.java
+++ b/nitrite-spatial/src/main/java/org/locationtech/jts/util/GeometricShapeFactoryExt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2024 Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.locationtech.jts.util;
 
 import net.sf.geographiclib.Geodesic;

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/CompoundFilterExampleTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/CompoundFilterExampleTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2017-2021 Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dizitart.no2.spatial;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.common.mapper.EntityConverter;
+import org.dizitart.no2.common.mapper.NitriteMapper;
+import org.dizitart.no2.common.mapper.SimpleNitriteMapper;
+import org.dizitart.no2.filters.Filter;
+import org.dizitart.no2.filters.FluentFilter;
+import org.dizitart.no2.repository.Cursor;
+import org.dizitart.no2.repository.ObjectRepository;
+import org.dizitart.no2.repository.annotations.Index;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.locationtech.jts.io.ParseException;
+
+import java.security.SecureRandom;
+
+import static org.dizitart.no2.collection.Document.createDocument;
+import static org.dizitart.no2.common.Constants.DOC_ID;
+import static org.dizitart.no2.common.Constants.DOC_MODIFIED;
+import static org.dizitart.no2.common.Constants.DOC_REVISION;
+import static org.dizitart.no2.common.Constants.DOC_SOURCE;
+import static org.dizitart.no2.index.IndexType.NON_UNIQUE;
+import static org.dizitart.no2.spatial.TestUtil.createDb;
+import static org.dizitart.no2.spatial.TestUtil.deleteDb;
+import static org.dizitart.no2.spatial.TestUtil.getRandomTempDbFile;
+
+public class CompoundFilterExampleTest {
+    private String fileName;
+    protected Nitrite db;
+    protected NitriteCollection collection;
+    protected ObjectRepository<PartiallyIndexedData> repository;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Index(fields = "indexString", type = NON_UNIQUE)
+    public static class PartiallyIndexedData {
+        private String indexStr;
+        private String otherStr;
+
+        public static class PidConverter implements EntityConverter<PartiallyIndexedData> {
+
+            @Override
+            public Class<PartiallyIndexedData> getEntityType() {
+                return PartiallyIndexedData.class;
+            }
+
+            @Override
+            public Document toDocument(PartiallyIndexedData entity, NitriteMapper nitriteMapper) {
+                return Document
+                    .createDocument("indexStr", entity.getIndexStr())
+                    .put("otherStr", entity.getOtherStr());
+            }
+
+            @Override
+            public PartiallyIndexedData fromDocument(Document document, NitriteMapper nitriteMapper) {
+                return new PartiallyIndexedData(
+                    document.get("indexStr", String.class),
+                    document.get("otherStr", String.class)
+                );
+            }
+        }
+    }
+
+    @Rule
+    public Retry retry = new Retry(3);
+
+
+    @Before
+    public void before() throws ParseException {
+        fileName = getRandomTempDbFile();
+        db = createDb(fileName);
+        try (SimpleNitriteMapper documentMapper = (SimpleNitriteMapper) db.getConfig().nitriteMapper()) {
+            documentMapper.registerEntityConverter(new PartiallyIndexedData.PidConverter());
+        }
+        repository = db.getRepository(PartiallyIndexedData.class);
+
+        insertObjects();
+    }
+
+    // Method to generate a random alphanumeric string of given length
+    public static String randomAlphanumeric(int length) {
+        // Define characters to choose from (alphanumeric)
+        String characters = "abcdefghijklmnopqrstuvwxyz";
+        SecureRandom random = new SecureRandom(new byte[] {0, 0, 0});
+
+        // StringBuilder to build the random string
+        StringBuilder randomString = new StringBuilder(length);
+
+        // Generate the random string
+        for (int i = 0; i < length; i++) {
+            int randomIndex = random.nextInt(characters.length());
+            randomString.append(characters.charAt(randomIndex));
+        }
+
+        // Return the random string
+        return randomString.toString();
+    }
+
+    protected void insertObjects() throws ParseException {
+        for (int i = 0; i < 10_000; i++) {
+            repository.insert(new PartiallyIndexedData(
+                randomAlphanumeric(2),
+                randomAlphanumeric(2)));
+        }
+    }
+
+    @After
+    public void after() {
+        if (db != null && !db.isClosed()) {
+            db.close();
+        }
+
+        deleteDb(fileName);
+    }
+
+    @Test
+    public void testMixedQuery() {
+        Cursor<PartiallyIndexedData> cursor = repository.find(Filter.and(
+            FluentFilter.where("indexStr").eq("aa"),
+            FluentFilter.where("otherStr").gt("kk")
+        ));
+        System.out.println("cursor.getFindPlan() = " + cursor.getFindPlan());
+        System.out.println("cursor.toList() = " + cursor.toList());
+    }
+
+    protected Document trimMeta(Document document) {
+        document.remove(DOC_ID);
+        document.remove(DOC_REVISION);
+        document.remove(DOC_MODIFIED);
+        document.remove(DOC_SOURCE);
+        return document;
+    }
+}

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
@@ -169,12 +169,12 @@ public class GeoSpatialFindNearTest extends GeoSpatialTestBase {
         // All of these distances should be within 10 metres of what was estimated on Google Earth.
 
         GeodesicData s12 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt2_950m_ESE.getX(), pt2_950m_ESE.getY());
-        assertEquals(s12.s12, 950.0, EPSILON_10M);
+        assertEquals(950.0, s12.s12, EPSILON_10M);
 
         GeodesicData s13 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt3_930m_W.getX(), pt3_930m_W.getY());
-        assertEquals(s13.s12, 930.0, EPSILON_10M);
+        assertEquals(930.0, s13.s12, EPSILON_10M);
 
         GeodesicData s14 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt4_2750m_WSW.getX(), pt4_2750m_WSW.getY());
-        assertEquals(s14.s12, 2750.0, EPSILON_10M);
+        assertEquals(2750.0, s14.s12, EPSILON_10M);
     }
 }

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Nitrite author or authors.
+ * Copyright (c) 2017-2024 Nitrite author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialFindNearTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2017-2021 Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.dizitart.no2.spatial;
+
+import net.sf.geographiclib.GeodesicData;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.FindOptions;
+import org.dizitart.no2.index.IndexOptions;
+import org.dizitart.no2.repository.Cursor;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
+import static net.sf.geographiclib.Geodesic.WGS84;
+import static org.dizitart.no2.collection.Document.createDocument;
+import static org.dizitart.no2.collection.FindOptions.orderBy;
+import static org.dizitart.no2.common.SortOrder.Ascending;
+import static org.dizitart.no2.common.util.Iterables.setOf;
+import static org.dizitart.no2.spatial.GeoSpatialTestBase.TestLocations.*;
+import static org.dizitart.no2.spatial.SpatialFluentFilter.where;
+import static org.dizitart.no2.spatial.SpatialIndexer.SPATIAL_INDEX;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases to check whether the Spatial distance search is properly converting meters to/from degrees and
+ * accounting for the curvature of the Earth.
+ * <p>
+ * From the <a href="https://nitrite.dizitart.com/java-sdk/filter/index.html#near-filter">"near filter"
+ * documentation</a>, it is clear that the intended use is for the arguments to represent (1) a geo-coordinate
+ * as a lat/long pair; and (2) a distance in meters.
+ * <p>
+ * This appears to disagree with the example provided in <pre>nitrite-spatial/README.md</pre>, which makes no
+ * mention of distance units uses a coordinate value outside the space of possible lat/long coordinates.
+ **/
+public class GeoSpatialFindNearTest extends GeoSpatialTestBase {
+
+    /** 2.5 kilometers, in meters */
+    private static final double DIST_2500_M = 2_500.0d;
+    /** 20 millimeters, in meters */
+    private static final double DIST_20_MM = (20.0d / 1000.0d);
+
+    /** Just sorting by "id" field so that JUnit's "Expected" vs. "Actual" output is easier to visually inspect. */
+    public static final FindOptions ORDER_BY_ID = orderBy("id", Ascending);
+    public static final Random RANDOM = new Random();
+
+    @Test
+    public void testNearFilter_ObjectRepository_FindsCorrectSubset() {
+        repository.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "geometry");
+        Cursor<SpatialData> cursor = repository.find(
+            where("geometry").near(centerPt.getCoordinate(), DIST_2500_M),
+            ORDER_BY_ID);
+
+        assertEquals("Near filter should only find two locations within 2.5km",
+            setOf(obj2_950m_ESE, obj3_930m_W),
+            cursor.toSet());
+    }
+
+    @Test
+    public void testNearFilter_NitriteCollection_FindsCorrectSubset() {
+        collection.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "location");
+
+        DocumentCursor cursor = collection.find(
+            where("location").near(centerPt.getCoordinate(), DIST_2500_M),
+            ORDER_BY_ID);
+
+        assertEquals("Near filter should only find two locations within 2.5km",
+            setOf(doc2_950m_ESE, doc3_930m_W),
+            cursor.toList().stream().map(this::trimMeta).collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void testNearFilter_ObjectRepository_SimpleEquatorDistances() {
+
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(0.0 1.00)"))); // 111km from (0,0)
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(0.0 0.01)"))); // 1.11km from (0,0)
+
+        repository.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "geometry");
+
+        Cursor<SpatialData> cursor = repository.find(where("geometry").near(new Coordinate(0.0, 0.0), 1120.0));
+
+        assertEquals("Near filter should find 1 location within 1.12km", 1, cursor.toList().size());
+    }
+
+    @Test
+    public void testNearFilter_NitriteCollection_SimpleEquatorDistances() {
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(0.0 1.00)")));
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(0.0 0.01)")));
+        collection.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "location");
+
+        DocumentCursor cursor = collection.find(where("location").near(new Coordinate(0.0, 0.0), 1120.0));
+
+        assertEquals("Near filter should find 1 location within 1.12km", 1, cursor.toList().size());
+    }
+
+    @Test
+    public void testNearFilter_ObjectRepository_Simple60NDistances() {
+
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(60.0 1.00)"))); // ~56km from (60,0)
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(60.0 2.00)"))); // ~111km from (60,0)
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(61.0 0.00)"))); // ~111km from (60,0)
+        repository.insert(new SpatialData(randLong(), readPoint("POINT(62.0 0.00)"))); // ~222km from (60,0)
+
+        repository.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "geometry");
+
+        Cursor<SpatialData> cursor = repository.find(
+            where("geometry").near(new Coordinate(60.0, 0.0), 112_000.0));
+
+        assertEquals("Near filter should find 3 locations within 1.12km", 3, cursor.toList().size());
+    }
+
+    @Test
+    public void testNearFilter_NitriteCollection_Simple60NDistances() {
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(60.0 1.00)")));  // ~56km from (60,0)
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(60.0 2.00)")));  // ~111km from (60,0)
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(61.0 0.00)")));  // ~111km from (60,0)
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(62.0 0.00)")));  // ~222km from (60,0)
+
+        // This point is outside the circle but inside the bounding box
+        collection.insert(createDocument("key", randLong()).put("location", readPoint("POINT(60.75 1.75)")));  // ~127km from (60,0)
+
+        collection.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "location");
+
+        DocumentCursor cursor = collection.find(where("location").near(new Coordinate(60.0, 0.0), 112_000.0));
+
+        assertEquals("Near filter should find 3 locations within 1.12km", 3, cursor.toList().size());
+    }
+
+    private static long randLong() {
+        return RANDOM.nextLong();
+    }
+
+    @Test
+    public void testNearFilter_ObjectRepository_TinyDistance_ReturnsNoResults() {
+        Coordinate coordinate = centerPt.getCoordinate();
+
+        Cursor<SpatialData> cursor = repository.find(where("geometry").near(coordinate, DIST_20_MM));
+        assertEquals("Near filter should return no results within 20mm distance", emptySet(), cursor.toSet());
+    }
+
+    @Test
+    public void testNearFilter_NitriteCollection_TinyDistance_ReturnsNoResults() {
+        Coordinate coordinate = centerPt.getCoordinate();
+
+        collection.createIndex(IndexOptions.indexOptions(SPATIAL_INDEX), "location");
+        DocumentCursor cursor = collection.find(where("location").near(coordinate, DIST_20_MM));
+        assertEquals("Near filter should return no results within 20mm distance", emptySet(), cursor.toSet());
+    }
+
+    @Test
+    public void testGeoLibrary_Distance_SanityCheck() {
+        final double EPSILON_10M = 10.0;
+        // All of these distances should be within 10 metres of what was estimated on Google Earth.
+
+        GeodesicData s12 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt2_950m_ESE.getX(), pt2_950m_ESE.getY());
+        assertEquals(s12.s12, 950.0, EPSILON_10M);
+
+        GeodesicData s13 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt3_930m_W.getX(), pt3_930m_W.getY());
+        assertEquals(s13.s12, 930.0, EPSILON_10M);
+
+        GeodesicData s14 = WGS84.Inverse(centerPt.getX(), centerPt.getY(), pt4_2750m_WSW.getX(), pt4_2750m_WSW.getY());
+        assertEquals(s14.s12, 2750.0, EPSILON_10M);
+    }
+}

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialTestBase.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/GeoSpatialTestBase.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017-2021 Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dizitart.no2.spatial;
+
+import lombok.SneakyThrows;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.repository.ObjectRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import static org.dizitart.no2.collection.Document.createDocument;
+import static org.dizitart.no2.common.Constants.DOC_ID;
+import static org.dizitart.no2.common.Constants.DOC_MODIFIED;
+import static org.dizitart.no2.common.Constants.DOC_REVISION;
+import static org.dizitart.no2.common.Constants.DOC_SOURCE;
+import static org.dizitart.no2.spatial.TestUtil.createDb;
+import static org.dizitart.no2.spatial.TestUtil.deleteDb;
+import static org.dizitart.no2.spatial.TestUtil.getRandomTempDbFile;
+
+public abstract class GeoSpatialTestBase {
+    private String fileName;
+    protected Nitrite db;
+    protected NitriteCollection collection;
+    protected ObjectRepository<SpatialData> repository;
+
+    static WKTReader reader = new WKTReader();
+    protected SpatialData obj2_950m_ESE, obj3_930m_W, obj4_2750m_WSW;
+    protected Document doc2_950m_ESE, doc3_930m_W, doc4_2750m_WSW;
+
+    @Rule
+    public Retry retry = new Retry(3);
+
+    /**
+     * I chose a set of simple landmarks in a major city at high latitude, near 60°N,
+     * such that the separation between them is primarily east-west.
+     * <p>
+     * At the equator, 1 degree of either latitude or longitude measures approx. 111km wide.
+     * However, at 60°N, 1 degree of longitude is only half as wide. (cf. cos(60°) == 0.5)
+     * <p>
+     * This math is not exact enough for the needs of a geographer, but it's close enough to create
+     * simple test cases that can distinguish whether we are properly converting meters to/from degrees,
+     * including accounting for the curvature of the Earth.
+     */
+    public static class TestLocations {
+        static Point centerPt = readPoint("POINT(59.91437 10.73402)");   // National Theater (Oslo)
+        static Point pt2_950m_ESE = readPoint("POINT(59.9115306 10.7501574)"); // Olso Central Station
+        static Point pt3_930m_W = readPoint("POINT(59.91433 10.71730)");  // National Library of Norway
+        static Point pt4_2750m_WSW = readPoint("POINT(59.90749 10.68670)");  //  Norwegian Museum of Cultural Hist.
+    }
+
+    @SneakyThrows
+    protected static Point readPoint(String wkt) {
+        return (Point) reader.read(wkt);
+    }
+
+    @Before
+    public void before() throws ParseException {
+        fileName = getRandomTempDbFile();
+        db = createDb(fileName);
+
+        collection = db.getCollection("test");
+        repository = db.getRepository(SpatialData.class);
+
+        insertObjects();
+        insertDocuments();
+    }
+
+    protected void insertObjects() throws ParseException {
+        obj2_950m_ESE = new SpatialData(2L, TestLocations.pt2_950m_ESE);
+        obj3_930m_W = new SpatialData(3L, TestLocations.pt3_930m_W);
+        obj4_2750m_WSW = new SpatialData(4L, TestLocations.pt4_2750m_WSW);
+        repository.insert(obj2_950m_ESE, obj3_930m_W, obj4_2750m_WSW);
+    }
+
+    protected void insertDocuments() throws ParseException {
+        doc2_950m_ESE = createDocument("key", 2L).put("location", TestLocations.pt2_950m_ESE);
+        doc3_930m_W = createDocument("key", 3L).put("location", TestLocations.pt3_930m_W);
+        doc4_2750m_WSW = createDocument("key", 4L).put("location", TestLocations.pt4_2750m_WSW);
+
+        collection.insert(doc2_950m_ESE, doc3_930m_W, doc4_2750m_WSW);
+    }
+
+    @After
+    public void after() {
+        if (db != null && !db.isClosed()) {
+            db.close();
+        }
+
+        deleteDb(fileName);
+    }
+
+    protected Document trimMeta(Document document) {
+        document.remove(DOC_ID);
+        document.remove(DOC_REVISION);
+        document.remove(DOC_MODIFIED);
+        document.remove(DOC_SOURCE);
+        return document;
+    }
+}

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialData.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialData.java
@@ -16,7 +16,9 @@
 
 package org.dizitart.no2.spatial;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.common.mapper.EntityConverter;
 import org.dizitart.no2.common.mapper.NitriteMapper;
@@ -30,6 +32,8 @@ import static org.dizitart.no2.spatial.SpatialIndexer.SPATIAL_INDEX;
  * @author Anindya Chatterjee
  */
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 @Index(fields = "geometry", type = SPATIAL_INDEX)
 public class SpatialData {
     @Id

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialData.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialData.java
@@ -50,7 +50,7 @@ public class SpatialData {
         @Override
         public Document toDocument(SpatialData entity, NitriteMapper nitriteMapper) {
             return Document.createDocument("id", entity.getId())
-                .put("geometry", nitriteMapper.tryConvert(entity.getGeometry(), Document.class));
+                .put("geometry", nitriteMapper.tryConvert(entity.getGeometry(), Geometry.class));
         }
 
         @Override

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialIndexTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialIndexTest.java
@@ -80,6 +80,31 @@ public class SpatialIndexTest extends BaseSpatialTest {
     }
 
     @Test
+    public void testWithinTriangleNotJustTestingBoundingBox() throws ParseException {
+
+        /*
+          (490, 530) * ┄┄┄┄┄.
+                     │\     ┆
+                     │ \  x<---(520, 520)
+                     │  \   ┆
+                     │   \  ┆
+                     │ x<-\---(500, 505)
+                     │     \┆
+          (490, 490) *──────* (530, 490)
+         */
+
+        WKTReader reader = new WKTReader();
+        Geometry search = reader.read("POLYGON((490 490, 530 490 , 490 530, 490 490))");
+
+        SpatialData outsidePoint = new SpatialData(7L, reader.read("POINT(520 520)"));
+        repository.insert(outsidePoint);
+
+        Cursor<SpatialData> cursor = repository.find(where("geometry").within(search));
+        assertEquals(cursor.size(), 1);
+        assertFalse(cursor.toList().contains(outsidePoint));
+    }
+
+    @Test
     public void testNearPoint() throws ParseException {
         WKTReader reader = new WKTReader();
         Point search = (Point) reader.read("POINT (490 490)");

--- a/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialIndexTest.java
+++ b/nitrite-spatial/src/test/java/org/dizitart/no2/spatial/SpatialIndexTest.java
@@ -83,14 +83,13 @@ public class SpatialIndexTest extends BaseSpatialTest {
     public void testWithinTriangleNotJustTestingBoundingBox() throws ParseException {
 
         /*
-          (490, 530) * ┄┄┄┄┄.
-                     │\     ┆
-                     │ \  x<---(520, 520)
-                     │  \   ┆
-                     │   \  ┆
-                     │ x<-\---(500, 505)
-                     │     \┆
-          (490, 490) *──────* (530, 490)
+          (490, 530) * - - -
+                     │\    -
+                     │ \ x <── (520, 520); outside triangle but within triangle's bounding box
+                     │  \  -
+                     │ x <── (500, 505); inside triangle
+                     │    \-
+          (490, 490) *─────* (530, 490)
          */
 
         WKTReader reader = new WKTReader();

--- a/nitrite/src/main/java/org/dizitart/no2/collection/operation/FindOptimizer.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/operation/FindOptimizer.java
@@ -53,8 +53,8 @@ class FindOptimizer {
     }
 
     private FindPlan createFilterPlan(Collection<IndexDescriptor> indexDescriptors, Filter filter) {
-        if (filter instanceof AndFilter) {
-            List<Filter> filters = flattenAndFilter((AndFilter) filter);
+        if (filter instanceof FlattenableFilter) {
+            List<Filter> filters = flattenFilter((FlattenableFilter) filter);
             return createAndPlan(indexDescriptors, filters);
         } else if (filter instanceof OrFilter) {
             return createOrPlan(indexDescriptors, ((OrFilter) filter).getFilters());
@@ -64,12 +64,12 @@ class FindOptimizer {
         }
     }
 
-    private List<Filter> flattenAndFilter(AndFilter andFilter) {
+    private List<Filter> flattenFilter(FlattenableFilter flattenableFilter) {
         List<Filter> flattenedFilters = new ArrayList<>();
-        if (andFilter != null) {
-            for (Filter filter : andFilter.getFilters()) {
-                if (filter instanceof AndFilter) {
-                    List<Filter> filters = flattenAndFilter((AndFilter) filter);
+        if (flattenableFilter != null) {
+            for (Filter filter : flattenableFilter.getFilters()) {
+                if (filter instanceof FlattenableFilter) {
+                    List<Filter> filters = flattenFilter((FlattenableFilter) filter);
                     flattenedFilters.addAll(filters);
                 } else {
                     flattenedFilters.add(filter);
@@ -174,7 +174,7 @@ class FindOptimizer {
             if (filter instanceof IndexOnlyFilter) {
                 IndexOnlyFilter indexScanFilter = (IndexOnlyFilter) filter;
                 if (isCompatibleFilter(indexOnlyFilters, indexScanFilter)) {
-                    // if filter is compatible with already identified index only filter then add
+                    // if filter is compatible with already identified index-only filter then add
                     indexOnlyFilters.add(indexScanFilter);
                 } else {
                     throw new FilterException("A query can not have multiple index only filters");

--- a/nitrite/src/main/java/org/dizitart/no2/filters/AndFilter.java
+++ b/nitrite/src/main/java/org/dizitart/no2/filters/AndFilter.java
@@ -27,7 +27,7 @@ import org.dizitart.no2.exceptions.FilterException;
  * @since 1.0
  */
 @Getter
-public class AndFilter extends LogicalFilter {
+public class AndFilter extends LogicalFilter implements FlattenableFilter {
 
     AndFilter(Filter... filters) {
         super(filters);

--- a/nitrite/src/main/java/org/dizitart/no2/filters/FlattenableFilter.java
+++ b/nitrite/src/main/java/org/dizitart/no2/filters/FlattenableFilter.java
@@ -21,9 +21,29 @@ import java.util.List;
 /**
  * Represents a filter which can be flattened or otherwise consists of multiple constituent filters.
  *
- * // TODO verify the "@since" version?
- * @since 4.4.0
+ * <p> [PR notes]
+ * <ul>
+ *     <li>We can't use {@code instanceof SomeClass} to trigger the application of "and"-like flattening,
+ *     because any classes defined in submodules aren't available here in the `nitrite` module at compile-time.
+ *     that interface of course needs to be here in the `nitrite` module, just like IndexOnlyFilter is.</li>
+ *
+ *     <li>There are plenty of things we could call this. "Andlike" was the first thing I came up with but
+ *     that sounded terrible. Flattenable is at least a "functional" naming, in that it says what it is, but this
+ *     also feels like it's asking for a {@code flatten} method to be added to the interface. But that then implies
+ *     that some of the logic in FindOptimizer would end up distributed across multiple classes. In its current state,
+ *     it's very helpful that all the related logic is right there in one file. </li>
+ *
+ *     <li>If we want to keep {@code getFilters} as the interface, then names like CompoundFilter and CompositeFilter
+ *     come to mind. However, that would leave FindOptimizer with a strange asymmetry where `and` is just a special
+ *     case of this interface but `or` is still its own thing with separate handling.</li>
+ * </ul>
+ *
+ * // TODO add a "@since" tag
  */
 public interface FlattenableFilter {
+    /**
+     * [PR note] Clearly this is not the ideal contract for this interface, but it allowed existing code to
+     * be leveraged to get the proof-of-concept working.
+     */
     List<Filter> getFilters();
 }

--- a/nitrite/src/main/java/org/dizitart/no2/filters/FlattenableFilter.java
+++ b/nitrite/src/main/java/org/dizitart/no2/filters/FlattenableFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017-2020. Nitrite author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dizitart.no2.filters;
+
+import java.util.List;
+
+/**
+ * Represents a filter which can be flattened or otherwise consists of multiple constituent filters.
+ *
+ * // TODO verify the "@since" version?
+ * @since 4.4.0
+ */
+public interface FlattenableFilter {
+    List<Filter> getFilters();
+}


### PR DESCRIPTION
## Why
With some additional work, this branch is intended to fix issue #1079. In its current state, there is still an unresolved issue where both `NearFilter` and `WithinFilter` actually just checking the minimal bounding box and never test the actual geometry.

My intended next step is to discuss the best path forward. I have left detailed notes in the form of a comment in the code with my understanding of options for expanding the fix.

## What 
* Added NearFilter unit test with real lat-long data. The current implementation of NearFilter doesn't return the expected results.
* Added a dependency on `net.sf.geographiclib : GeographicLib-Java : 2.0` in `nitrite-spatial/pom.xml`
* Added an alternative "geometry factory" that creates a [geodetic "small circle"](https://en.wikipedia.org/wiki/Spherical_circle) instead of a cartesian circle as the existing JTS geometry factory does.
   * I'm happy to refactor this in any number of ways. This current implementation is just what I felt was the most straightforward replacement for existing functionality, serving as a proof of concept without forcing a ripple of changed type signatures.
* Added another unit test to check the behavior of `WithinFilter` once I stepped through in the debugger and saw that `SpatialIndex.java` is mistakenly treating the filter work as done after the initial RTree check. Sure enough, the same problem occurs for `WithinFilter`. I added an ASCII diagram in a comment within the new unit test, `testWithinTriangleNotJustTestingBoundingBox`.
