### PR TITLE
Revert dependency version regression, fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: daily
     target-branch: main
+    ignore:
+      # Ignore minor version updates for dependencies with group ID "com.google.errorprone"
+      - dependency-name: "com.google.errorprone:*"
+        update-types: [ "version-update:semver-minor" ]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,33 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     target-branch: main
     ignore:
       # Ignore minor version updates for dependencies with group ID "com.google.errorprone"
       - dependency-name: "com.google.errorprone:*"
         update-types: [ "version-update:semver-minor" ]
+    groups:
+      security:
+        # Group security updates into a single pull request
+        applies-to: security-updates
+        patterns:
+          - "*"
+      production-dependencies:
+        # Group version updates for "production" dependencies into a single pull request
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - "*"
+      development-dependencies:
+        # Group version updates for "development" dependencies into a single pull request
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: main

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <threetenbp.version>1.7.0</threetenbp.version>
 
         <!-- Error Prone version > 2.31.0 can't run on JDK 11. see https://errorprone.info/docs/installation -->
-        <error-prone.version>2.36.0</error-prone.version>
+        <error-prone.version>2.31.0</error-prone.version>
 
         <jacoco.version>0.8.12</jacoco.version>
         <surefire.version>3.5.2</surefire.version>


### PR DESCRIPTION
> UPDATE: I tried using [Azul Zulu](https://www.azul.com/downloads/?package=jdk#zulu), the same specific JDK distribution as the CI uses, and found that for some reason it was able to build successfully. 
>
> Knowing this, how do you want to proceed? Should we advise contributors building on Java 11 to use the Azul JDK, or pin the `errorprone` version?

<hr>

Dependabot suggested to change `error-prone` library to 2.36.0 again in #1089, and it was accepted/merged, which re-breaks the fix that was included in #1083. 

In order to prevent future such regressions, I took it upon myself to configure `dependabot` to ignore certain packages. The [documentation ](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) is thorough but lacks examples. I found [this config in the wild](https://github.com/apache/logging-log4j2/blob/bc71bc007de18699a0a8a705d95ac17b3a11edbe/.github/dependabot.yaml#L197) via Github search and it made the usage clear enough.

Then I did some additional research to understand how to make the update PRs less noisy via ["groups"](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates). Here are a couple of examples of dependabot `groups` usage in projects that I would expect know what they're doing: [1](https://github.com/SAP/ai-sdk-java/blob/a7b2b8760dcd372ed62404127113d9ab11d4c6fc/.github/dependabot.yaml#L14), [2](https://github.com/google/auto/blob/0227da18449c31e7165e194fadd3ef85bd02dfef/.github/dependabot.yml#L34), [3](https://github.com/CERIT-SC/sensitive-data-archive/blob/6ec4cf4e36e00f1e43bf403ef9acab832b802dd1/.github/dependabot.yaml#L88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Management**
	- Updated Dependabot configuration to check for dependency updates weekly
	- Created groups for security, production, and development dependencies
	- Configured specific ignore rules for certain dependency updates

- **Dependency Version**
	- Downgraded error-prone tool version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->