### PR TITLE
Change NitriteId to use `long` internally to avoid parseLong overhead

### DIFF
--- a/nitrite-jackson-mapper/src/main/java/org/dizitart/no2/mapper/jackson/modules/NitriteIdSerializer.java
+++ b/nitrite-jackson-mapper/src/main/java/org/dizitart/no2/mapper/jackson/modules/NitriteIdSerializer.java
@@ -35,8 +35,6 @@ class NitriteIdSerializer extends StdScalarSerializer<NitriteId> {
 
     @Override
     public void serialize(NitriteId value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        if (value.getIdValue() != null) {
-            gen.writeString(value.getIdValue());
-        }
+        gen.writeString(Long.toString(value.getIdValue()));
     }
 }

--- a/nitrite-mvstore-adapter/src/main/java/org/dizitart/no2/mvstore/NitriteMVRTreeMap.java
+++ b/nitrite-mvstore-adapter/src/main/java/org/dizitart/no2/mvstore/NitriteMVRTreeMap.java
@@ -43,8 +43,8 @@ class NitriteMVRTreeMap<Key extends BoundingBox, Value> implements NitriteRTree<
 
     @Override
     public void add(Key key, NitriteId nitriteId) {
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            MVSpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            MVSpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
             try {
                 mvMap.add(spatialKey, key);
@@ -56,8 +56,8 @@ class NitriteMVRTreeMap<Key extends BoundingBox, Value> implements NitriteRTree<
 
     @Override
     public void remove(Key key, NitriteId nitriteId) {
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            MVSpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            MVSpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
             try {
                 mvMap.remove(spatialKey);

--- a/nitrite-rocksdb-adapter/src/main/java/org/dizitart/no2/rocksdb/RocksDBRTree.java
+++ b/nitrite-rocksdb-adapter/src/main/java/org/dizitart/no2/rocksdb/RocksDBRTree.java
@@ -46,8 +46,8 @@ public class RocksDBRTree<Key extends BoundingBox, Value> implements NitriteRTre
     @Override
     public void add(Key key, NitriteId nitriteId) {
         checkOpened();
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             backingMap.put(spatialKey, key);
         }
     }
@@ -55,8 +55,8 @@ public class RocksDBRTree<Key extends BoundingBox, Value> implements NitriteRTre
     @Override
     public void remove(Key key, NitriteId nitriteId) {
         checkOpened();
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             backingMap.remove(spatialKey);
         }
     }

--- a/nitrite-rocksdb-adapter/src/main/java/org/dizitart/no2/rocksdb/formatter/NitriteSerializers.java
+++ b/nitrite-rocksdb-adapter/src/main/java/org/dizitart/no2/rocksdb/formatter/NitriteSerializers.java
@@ -34,7 +34,7 @@ public class NitriteSerializers {
 
         @Override
         protected void writeKeyInternal(Kryo kryo, Output output, NitriteId object) {
-            output.writeString(object.getIdValue());
+            output.writeString(Long.toString(object.getIdValue()));
         }
 
         @Override

--- a/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/NitriteDocument.java
@@ -103,7 +103,8 @@ class NitriteDocument extends LinkedHashMap<String, Object> implements Document 
 
     @Override
     public NitriteId getId() {
-        String id;
+        long id;
+        Object retrievedId = null;
         try {
             // if _id field is not populated already, create a new id
             // and set, otherwise return the existing id
@@ -111,12 +112,20 @@ class NitriteDocument extends LinkedHashMap<String, Object> implements Document 
                 id = newId().getIdValue();
                 super.put(DOC_ID, id);
             } else {
-                id = (String) get(DOC_ID);
+               retrievedId = get(DOC_ID);
+               id = (long) get(DOC_ID);
             }
 
             // create a nitrite id instance from the string value
             return createId(id);
         } catch (ClassCastException cce) {
+            if (retrievedId != null && retrievedId instanceof String) {
+                try {
+                    return createId((String) retrievedId);
+                } catch (InvalidIdException ide) {
+                    // fall through to throw InvalidIdException below
+                }
+            }
             throw new InvalidIdException("Invalid _id found " + get(DOC_ID));
         }
     }

--- a/nitrite/src/main/java/org/dizitart/no2/collection/NitriteId.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/NitriteId.java
@@ -47,18 +47,18 @@ public final class NitriteId implements Comparable<NitriteId>, Serializable {
     private static final long serialVersionUID = 1477462375L;
     private static final SnowflakeIdGenerator generator = new SnowflakeIdGenerator();
 
-    /**
-     *  Gets the underlying value of the NitriteId.
-     *  <p>
-     *  The value is a string representation of a 64bit integer number.
-     */
-    private String idValue;
+    /** The underlying value of the NitriteId. */
+    private long idValue;
 
     private NitriteId() {
-        this.idValue = Long.toString(generator.getId());
+        this.idValue = generator.getId();
     }
 
     private NitriteId(String value) {
+        this.idValue = Long.parseLong(value);
+    }
+
+    private NitriteId(long value) {
         this.idValue = value;
     }
 
@@ -85,6 +85,17 @@ public final class NitriteId implements Comparable<NitriteId>, Serializable {
     }
 
     /**
+     * Creates a {@link NitriteId} from a {@code long} value.
+     *
+     * @param value the value
+     * @return the {@link NitriteId}
+     */
+    public static NitriteId createId(long value) {
+        validId(value);
+        return new NitriteId(value);
+    }
+
+    /**
      * Validates a value to be used as {@link NitriteId}.
      * <p>
      * The value must be a string representation of a 64bit integer number.
@@ -106,26 +117,19 @@ public final class NitriteId implements Comparable<NitriteId>, Serializable {
 
     @Override
     public int compareTo(NitriteId other) {
-        if (other.idValue == null) {
-            throw new InvalidIdException("Cannot compare with null id");
-        }
-
-        return Long.compare(Long.parseLong(idValue), Long.parseLong(other.idValue));
+        return Long.compare(idValue, other.idValue);
     }
 
     @Override
     public String toString() {
-        if (idValue != null) {
-            return ID_PREFIX + idValue + ID_SUFFIX;
-        }
-        return "";
+        return ID_PREFIX + idValue + ID_SUFFIX;
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {
-        stream.writeUTF(idValue);
+        stream.writeUTF(Long.toString(idValue));
     }
 
     private void readObject(ObjectInputStream stream) throws IOException {
-        idValue = stream.readUTF();
+        idValue = Long.parseLong(stream.readUTF());
     }
 }

--- a/nitrite/src/main/java/org/dizitart/no2/collection/operation/ReadOperations.java
+++ b/nitrite/src/main/java/org/dizitart/no2/collection/operation/ReadOperations.java
@@ -135,7 +135,7 @@ class ReadOperations {
             // and or single filter
             if (findPlan.getByIdFilter() != null) {
                 FieldBasedFilter byIdFilter = findPlan.getByIdFilter();
-                NitriteId nitriteId = NitriteId.createId((String) byIdFilter.getValue());
+                NitriteId nitriteId = NitriteId.createId((long) byIdFilter.getValue());
                 if (nitriteMap.containsKey(nitriteId)) {
                     Document document = nitriteMap.get(nitriteId);
                     rawStream = RecordStream.single(pair(nitriteId, document));

--- a/nitrite/src/main/java/org/dizitart/no2/store/memory/InMemoryRTree.java
+++ b/nitrite/src/main/java/org/dizitart/no2/store/memory/InMemoryRTree.java
@@ -39,8 +39,8 @@ public class InMemoryRTree<Key extends BoundingBox, Value> implements NitriteRTr
     @Override
     public void add(Key key, NitriteId nitriteId) {
         checkOpened();
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             backingMap.put(spatialKey, key);
         }
     }
@@ -48,8 +48,8 @@ public class InMemoryRTree<Key extends BoundingBox, Value> implements NitriteRTr
     @Override
     public void remove(Key key, NitriteId nitriteId) {
         checkOpened();
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             backingMap.remove(spatialKey);
         }
     }

--- a/nitrite/src/main/java/org/dizitart/no2/transaction/TransactionalRTree.java
+++ b/nitrite/src/main/java/org/dizitart/no2/transaction/TransactionalRTree.java
@@ -26,16 +26,16 @@ class TransactionalRTree<Key extends BoundingBox, Value> implements NitriteRTree
 
     @Override
     public void add(Key key, NitriteId nitriteId) {
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             map.put(spatialKey, key);
         }
     }
 
     @Override
     public void remove(Key key, NitriteId nitriteId) {
-        if (nitriteId != null && nitriteId.getIdValue() != null) {
-            SpatialKey spatialKey = getKey(key, Long.parseLong(nitriteId.getIdValue()));
+        if (nitriteId != null) {
+            SpatialKey spatialKey = getKey(key, nitriteId.getIdValue());
             map.remove(spatialKey);
         }
     }

--- a/nitrite/src/test/java/org/dizitart/no2/collection/NitriteDocumentTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/collection/NitriteDocumentTest.java
@@ -56,8 +56,8 @@ public class NitriteDocumentTest {
     @Test
     public void testGetId() {
         NitriteDocument nitriteDocument = new NitriteDocument();
-        nitriteDocument.putIfAbsent("_id", "42");
-        assertEquals("42", nitriteDocument.getId().getIdValue());
+        nitriteDocument.putIfAbsent("_id", 42L);
+        assertEquals(42L, nitriteDocument.getId().getIdValue());
     }
 
     @Test

--- a/nitrite/src/test/java/org/dizitart/no2/collection/NitriteIdTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/collection/NitriteIdTest.java
@@ -60,7 +60,7 @@ public class NitriteIdTest {
 
     @Test
     public void testCreateId() {
-        assertEquals("42", NitriteId.createId("42").getIdValue());
+        assertEquals(42L, NitriteId.createId("42").getIdValue());
         assertThrows(InvalidIdException.class, () -> NitriteId.createId(null));
         assertThrows(InvalidIdException.class, () -> NitriteId.createId("Value"));
     }

--- a/nitrite/src/test/java/org/dizitart/no2/filters/FilterTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/filters/FilterTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.*;
 public class FilterTest {
     @Test
     public void testById() {
-        assertTrue(((EqualsFilter) Filter.byId(NitriteId.newId())).getValue() instanceof String);
+        assertTrue(((EqualsFilter) Filter.byId(NitriteId.newId())).getValue() instanceof Long);
         assertFalse(((EqualsFilter) Filter.byId(NitriteId.newId())).getObjectFilter());
         assertEquals("_id", ((EqualsFilter) Filter.byId(NitriteId.newId())).getField());
     }


### PR DESCRIPTION
I made [some changes in the JMH repo](https://github.com/leoger/nitrite-jmh/actions/runs/13647548525) to enable testing specific branches more easily, and then ran a pair of jobs that I think you'll want to have a close look at:

* benchmarks with current `main`: https://github.com/leoger/nitrite-jmh/actions/runs/13646173992
* benchmarks with NitriteId changed from String to long: https://github.com/leoger/nitrite-jmh/actions/runs/13647548525

**For some of the benchmark cases, it makes Nitrite nearly 50% faster.** This roughly matches what I observed in stack-sampling CPU profiler data collected on production servers where my team is using Nitrite.

I enabled the JMH stack profiler on those branches, so you can see some rough data on where the code is spending its time.  The library is doing a lot of comparison of record IDs, which is not surprising at all -- that's a fundamental thing we expect of a DB for it's internal bookkeeping. The problem is that when our id is a string and we want that string to sort numerically rather than lexically, there are extra hoops to jump through. Every one of those comparisons is currently very expensive because it triggers the parsing of both strings, compares the numeric values, and immediately throws the result of those computationally expensive parses away. Meanwhile, comparing two `long` values is a primitive operation for the CPU so it costs a single clock cycle. 

If you're truly dedicated to the idea that they must be strings in memory at runtime, there are other tricks we could do to minimize the need for parsing, but I strongly advise against it. By simply adjusting the serialization to read the ID in as a String and immediately parse it when loading from a file, we can avoid problems of portability across languages and not have to worry about breaking compatibility for users with existing Nitrite DB files. I do want to be careful with back-compat, so please advise whether there are any additional DB-file-loading scenarios that are not covered by unit tests that would catch if this were actually a breaking change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized identifier handling by converting document and record IDs to numeric values for improved consistency and robustness in data processing.
- **Tests**
  - Updated validation tests to reflect the new numeric ID approach, ensuring alignment and reliability across system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->