### PR TITLE
[REFACTOR]  Avoid double lookups in keyed repo checks; trim names; clarify opened check in Nitrite.java

### DIFF
--- a/nitrite/src/main/java/org/dizitart/no2/Nitrite.java
+++ b/nitrite/src/main/java/org/dizitart/no2/Nitrite.java
@@ -312,9 +312,11 @@ public interface Nitrite extends AutoCloseable {
      */
     default <T> boolean hasRepository(Class<T> type, String key) {
         checkOpened();
+        Map<String, Set<String>> keyed = listKeyedRepositories();
+        Set<String> entities = keyed.get(key);
+        if (entities == null) return false;
         String entityName = ObjectUtils.getEntityName(type);
-        return listKeyedRepositories().containsKey(key)
-                && listKeyedRepositories().get(key).contains(entityName);
+        return entities.contains(entityName);
     }
 
     /**
@@ -343,8 +345,10 @@ public interface Nitrite extends AutoCloseable {
      */
     default <T> boolean hasRepository(EntityDecorator<T> entityDecorator, String key) {
         checkOpened();
-        return listKeyedRepositories().containsKey(key)
-                && listKeyedRepositories().get(key).contains(entityDecorator.getEntityName());
+        Map<String, Set<String>> keyed = listKeyedRepositories();
+        Set<String> entities = keyed.get(key);
+        if (entities == null) return false;
+        return entities.contains(entityDecorator.getEntityName());
     }
 
     /**
@@ -355,11 +359,12 @@ public interface Nitrite extends AutoCloseable {
      *                             reserved names
      */
     default void validateCollectionName(String name) {
-        notNull(name, "name cannot be null");
-        notEmpty(name, "name cannot be empty");
+       notNull(name, "name cannot be null");
+       String normalized = name.trim();
+       notEmpty(normalized, "name cannot be empty");
 
         for (String reservedName : RESERVED_NAMES) {
-            if (name.contains(reservedName)) {
+            if (normalized.contains(reservedName)) {
                 throw new ValidationException("Name cannot contain " + reservedName);
             }
         }


### PR DESCRIPTION
- Avoid double Map lookups and null chaining in keyed-repository existence checks by using a single get() and null guard.
- Trim collection names in validateCollectionName before emptiness and reserved-token checks.
- Keep closed-store guard centralized in checkOpened() for all callers.

@anidotnet I have refactored and tested all my changes as well. They passed. 
Can you please review and merge?
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Collection name validation now trims whitespace before checks, preventing unexpected rejections and improving detection of reserved names.

- Refactor
  - Streamlined repository existence checks to eliminate redundant lookups, improving performance when working with keyed repositories, especially at scale.
  - Internal logic improvements only; no changes to public APIs or configuration. Behavior remains backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->