### PR TITLE
fix: default MVStore pageSplitSize to 16 KB, not 16 bytes

### DIFF
--- a/nitrite-mvstore-adapter/src/main/java/org/dizitart/no2/mvstore/MVStoreModuleBuilder.java
+++ b/nitrite-mvstore-adapter/src/main/java/org/dizitart/no2/mvstore/MVStoreModuleBuilder.java
@@ -107,9 +107,15 @@ public class MVStoreModuleBuilder {
 
     /**
      * The amount of memory a MVStore page should contain at most, in bytes,
-     * before it is split. The default is 16 KB.
+     * before it is split. The default is 16 KB, which is also MVStore's own
+     * default for a persistent store.
+     * <p>
+     * MVStore reads this value in bytes. It used to default to {@code 16}, so
+     * every leaf page split as soon as it held more than one entry: a store
+     * carried roughly one entry per page, and every lookup descended a tree
+     * about twice as deep as it needed to be.
      */
-    private int pageSplitSize = 16;
+    private int pageSplitSize = 16 * 1024;
 
     /**
      * The file store used by the MVStore.

--- a/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/mvstore/MVStoreModuleBuilderTest.java
+++ b/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/mvstore/MVStoreModuleBuilderTest.java
@@ -33,7 +33,7 @@ public class MVStoreModuleBuilderTest {
         assertTrue(actualMvStoreModuleBuilder.autoCommit());
         assertFalse(actualMvStoreModuleBuilder.recoveryMode());
         assertFalse(actualMvStoreModuleBuilder.readOnly());
-        assertEquals(Short.SIZE, actualMvStoreModuleBuilder.pageSplitSize());
+        assertEquals(16 * 1024, actualMvStoreModuleBuilder.pageSplitSize());
         assertNull(actualMvStoreModuleBuilder.fileStore());
         assertEquals("Path", actualMvStoreModuleBuilder.filePath());
         assertTrue(actualMvStoreModuleBuilder.eventListeners().isEmpty());
@@ -66,7 +66,7 @@ public class MVStoreModuleBuilderTest {
         MVStoreModuleBuilder actualMvStoreModuleBuilder = new MVStoreModuleBuilder();
         assertTrue(actualMvStoreModuleBuilder.autoCommit());
         assertFalse(actualMvStoreModuleBuilder.recoveryMode());
-        assertEquals(Short.SIZE, actualMvStoreModuleBuilder.pageSplitSize());
+        assertEquals(16 * 1024, actualMvStoreModuleBuilder.pageSplitSize());
         assertTrue(actualMvStoreModuleBuilder.eventListeners().isEmpty());
         assertEquals(1024, actualMvStoreModuleBuilder.autoCommitBufferSize());
         assertEquals(Short.SIZE, actualMvStoreModuleBuilder.cacheSize());

--- a/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/mvstore/MVStoreModuleTest.java
+++ b/nitrite-mvstore-adapter/src/test/java/org/dizitart/no2/mvstore/MVStoreModuleTest.java
@@ -33,7 +33,7 @@ public class MVStoreModuleTest {
         MVStoreModuleBuilder actualWithConfigResult = MVStoreModule.withConfig();
         assertTrue(actualWithConfigResult.autoCommit());
         assertFalse(actualWithConfigResult.recoveryMode());
-        assertEquals(Short.SIZE, actualWithConfigResult.pageSplitSize());
+        assertEquals(16 * 1024, actualWithConfigResult.pageSplitSize());
         assertTrue(actualWithConfigResult.eventListeners().isEmpty());
         assertEquals(1024, actualWithConfigResult.autoCommitBufferSize());
         assertEquals(Short.SIZE, actualWithConfigResult.cacheSize());


### PR DESCRIPTION
MVStoreModuleBuilder.pageSplitSize is documented as "16 KB" and is passed straight to MVStore.Builder.pageSplitSize, which takes bytes. Its value was 16, the same literal used for cacheSize (megabytes) and cacheConcurrency (a count), so every leaf page split as soon as it held more than one entry.

Measured by rebuilding a 146 MB store of 46,926 entries at each setting: 93,781 pages at depth 13 with 16; 36,096 pages at depth 12 with MVStore's own persistent-store default of 16 KB; 13,327 pages at depth 6 with 64 KB, the largest value that survives H2's (cacheSize / cacheConcurrency) >> 4 clamp.

The default is now 16 * 1024, matching the javadoc and MVStore's default. Existing files are unaffected until their pages are rewritten; there is nothing to migrate. The two tests that pinned the old literal through Short.SIZE are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default MVStore page split size from 16 bytes to 16 KB.
  * Reduced excessive page splitting when using the default configuration.

* **Documentation**
  * Updated configuration documentation to accurately describe the default page split size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->